### PR TITLE
Angular Examples: Enable symlinked NPM packages

### DIFF
--- a/angular-ids-wc/angular.json
+++ b/angular-ids-wc/angular.json
@@ -34,7 +34,8 @@
             "buildOptimizer": false,
             "sourceMap": true,
             "optimization": false,
-            "namedChunks": true
+            "namedChunks": true,
+            "preserveSymlinks": true
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
**Describe what this PR addresses:**
Previously, the angular examples were not loading symlinked packages from node_modules folder correctly.  This made our process for `npm link ids-enterprise-wc` for local development of the examples impossible. 

After some investigation it turns out symlinked packages need to explicitly be enabled as a setting in `angular.json`: https://stackoverflow.com/a/59078572

This PR just flips the switch to enable symlinking.

**Steps to test**:
- pull the latest [IDS Enterprise Web Components]()
- pull this branch
- in WC, run `npm run publish:link` to build the library and store it as local NPM package
- in this project, open the Angular components folder and run `npm uninstall ids-enterprise-wc && npm link ids-enterprise-wc` to symlink the local NPM package
- run `npm start`  There should be no compilation errors
