### PR TITLE
792 - Add more Sveltekit examples

### DIFF
--- a/sveltekit-ids-wc/doc/CHECKLIST.md
+++ b/sveltekit-ids-wc/doc/CHECKLIST.md
@@ -2,7 +2,7 @@
 
 ## Components To Convert
 
-Components marked completed in this checklist will have both an example of direct usage AND an example using a Svelte component wrapper
+Components marked completed in this checklist will have an example of direct usage in Sveltekit.
 
  - [ ] About (ids-about)
  - [ ] Accordion (ids-accordion)
@@ -25,6 +25,7 @@ Components marked completed in this checklist will have both an example of direc
  - [ ] Cards (ids-card)
  - [x] Checkboxes (ids-checkbox)
  - [ ] Circle Pager (ids-scroll-view)
+ - [x] Color (swatch) (ids-color)
  - [ ] Color Picker (ids-color-picker)
  - [ ] Column (ids-column-chart or ids-bar with a orientation setting)
  - [ ] Completion Chart (ids-progress-chart)
@@ -41,13 +42,13 @@ Components marked completed in this checklist will have both an example of direc
  - [ ] Expandable area (ids-expandable-area)
  - [ ] Fieldset (ids-field-set)
  - [ ] Fontpicker (added as part of editor)
- - [ ] Form  (ids-form)
+ - [ ] Form (ids-form)
  - [ ] Grid (ids-layout-grid)
  - [ ] Header (ids-header)
  - [ ] Hierarchy (ids-hierarchy)
  - [ ] Homepage (ids-homepage)
- - [ ] Hyperlinks (ids-hyperlink)
- - [ ] Icons (ids-icon)
+ - [x] Hyperlinks (ids-hyperlink)
+ - [x] Icons (ids-icon)
  - [ ] Images (ids-image)
  - [x] Input (ids-input)
  - [ ] (Layout) Responsive Grid (ids-layout-grid)
@@ -58,12 +59,12 @@ Components marked completed in this checklist will have both an example of direc
  - [ ] Loading indicator (ids-loading-indicator) aka Busy Indicator / Loader
  - [ ] Locale (ids-locale)
  - [ ] Lookup (ids-lookup)
- - [ ] Mask (ids-mask)
+ - [x] Mask (ids-mask)
  - [ ] Masthead (ids-masthead)
  - [ ] Menu (ids-menu)
  - [ ] MenuButton (ids-menu-button)
  - [ ] Message (ids-message)
- - [ ] Modal (ids-modal)
+ - [x] Modal (ids-modal)
  - [ ] Monthview (ids-month-view)
  - [ ] Multiselect (ids-multi-select)
  - [ ] Notification (ids-notification-banner)
@@ -72,8 +73,8 @@ Components marked completed in this checklist will have both an example of direc
  - [ ] Pager (ids-pager)
  - [ ] Personalize (ids-personalize or as amixin on components thats support)
  - [ ] Pie (ids-pie-chart)
- - [ ] Popup (ids-popup)
- - [ ] Popupmenu (ids-men
+ - [x] Popup (ids-popup)
+ - [x] Popupmenu (ids-popup-menu)
  - [ ] Positive Negative (ids-positive-negative-chart) skipping until needed
  - [ ] Radar (ids-radar-chart) skipping until needed
  - [ ] Radios (ids-radio)
@@ -88,16 +89,16 @@ Components marked completed in this checklist will have both an example of direc
  - [ ] Spinbox (ids-spin-box)
  - [ ] Splitter (ids-splitter)
  - [ ] Stepchart (ids-step-chart)
- - [ ] Swaplist (ids-swap-list)
+ - [x] Swaplist (ids-swap-list)
  - [ ] Switch (ids-switch)
- - [ ] Tabs (ids-tabs)
- - [ ] Tabs Header (ids-tabs with option)
- - [ ] Tabs Module (ids-tabs with option)
+ - [x] Tabs (ids-tabs)
+ - [x] Tabs Header (ids-tabs with option)
+ - [x] Tabs Module (ids-tabs with option)
  - [ ] Tabs Multi (ids-tabs with option) skipping until needed
- - [ ] Tabs Vertical (ids-tabs with option)
+ - [x] Tabs Vertical (ids-tabs with option)
  - [x] Tag (ids-tag)
  - [ ] Targeted Achievement (ids-progress-chart)
- - [ ] Textarea (ids-textarea)
+ - [x] Textarea (ids-textarea)
  - [ ] Timeline (ids-time-line) skipping until needed (also have process indicator)
  - [ ] Timepicker (ids-time-picker)
  - [ ] Toast (ids-toast)
@@ -107,7 +108,7 @@ Components marked completed in this checklist will have both an example of direc
  - [ ] Tree (ids-tree)
  - [ ] Treemap (ids-tree-map)
  - [ ] Trigger Field (ids-trigger-field)
- - [ ] Typography (ids-text)
+ - [x] Typography (ids-text)
  - [ ] Upload (ids-upload)
  - [ ] Upload Advanced (ids-upload-advanced)
  - [ ] Validation (ids-validation-mixin)

--- a/sveltekit-ids-wc/src/app.html
+++ b/sveltekit-ids-wc/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<link rel="icon" href="/%sveltekit.assets%/favicon.png" />
 		<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600&amp;amp;display=swap" rel="stylesheet">
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%

--- a/sveltekit-ids-wc/src/app.html
+++ b/sveltekit-ids-wc/src/app.html
@@ -7,7 +7,5 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
 	</head>
-	<body>
-		<div>%sveltekit.body%</div>
-	</body>
+	<body>%sveltekit.body%</body>
 </html>

--- a/sveltekit-ids-wc/src/app.store.ts
+++ b/sveltekit-ids-wc/src/app.store.ts
@@ -1,0 +1,10 @@
+import { writable } from 'svelte/store';
+
+/**
+ * Creates a Svelte Store for global application settings
+ */
+
+export const appStore = writable({
+  allowThemeSwitcher: true,
+  debug: false,
+});

--- a/sveltekit-ids-wc/src/components/ids-dropdown/IdsDropdown.svelte
+++ b/sveltekit-ids-wc/src/components/ids-dropdown/IdsDropdown.svelte
@@ -13,6 +13,11 @@
   });
 </script>
 
-<ids-dropdown {id} {label} dirty-tracker={dirtyTracker} {value}>
+<ids-dropdown
+  dirty-tracker={dirtyTracker}
+  {id}
+  {label}
+  {value}
+  on:change>
   <slot></slot>
 </ids-dropdown>

--- a/sveltekit-ids-wc/src/components/ids-hyperlink/IdsHyperLink.svelte
+++ b/sveltekit-ids-wc/src/components/ids-hyperlink/IdsHyperLink.svelte
@@ -1,0 +1,35 @@
+<svelte:options accessors />
+
+<script lang="ts">
+	import { createEventDispatcher, onMount } from 'svelte';
+
+	onMount(async () => {
+		await import('ids-enterprise-wc/components/ids-hyperlink/ids-hyperlink');
+	});
+
+	const dispatch = createEventDispatcher();
+
+  type IdsTextFontWeight = null | 'bold' | 'lighter';
+  type IdsTextFontSize = null;
+
+  export let disabled: boolean = false;
+  export let fontWeight: IdsTextFontWeight = null;
+  export let fontSize: IdsTextFontSize = null;
+	export let id: string | null = '';
+	export let href: string | null = null;
+	export let target: string | null = null;
+  export let textDecoration: string | null = '';
+</script>
+
+<ids-hyperlink 
+  id={`dynamic-hyperlink-${id}`} 
+  data-id={id}
+  {disabled}
+  {fontWeight}
+  {fontSize}
+  {href} 
+  {target}
+  text-decoration={textDecoration}
+  on:click>
+  <slot></slot>
+</ids-hyperlink>

--- a/sveltekit-ids-wc/src/routes/__layout-fullpage.svelte
+++ b/sveltekit-ids-wc/src/routes/__layout-fullpage.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  
+  // IDS Components are rendered client-side.
+  // This example demonstrates how dynamic imports can load IDS Components client-side while still allowing for Svelte SSR
+  onMount(async (): Promise<void> => {
+    Promise.all([
+      await import('ids-enterprise-wc/components/ids-text/ids-text'),
+      await import('ids-enterprise-wc/components/ids-hyperlink/ids-hyperlink'),
+      await import('ids-enterprise-wc/components/ids-card/ids-card'),
+      await import('ids-enterprise-wc/components/ids-theme-switcher/ids-theme-switcher'),
+      await import('ids-enterprise-wc/components/ids-block-grid/ids-block-grid'),
+      await import('ids-enterprise-wc/components/ids-layout-grid/ids-layout-grid'),
+      await import('ids-enterprise-wc/components/ids-container/ids-container')
+    ]);
+  });
+</script>
+
+<ids-container padding="0">
+  <slot></slot>
+</ids-container>

--- a/sveltekit-ids-wc/src/routes/__layout.svelte
+++ b/sveltekit-ids-wc/src/routes/__layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { appStore } from '../app.store';
   
   // IDS Components are rendered client-side.
   // This example demonstrates how dynamic imports can load IDS Components client-side while still allowing for Svelte SSR
@@ -8,6 +9,7 @@
       await import('ids-enterprise-wc/components/ids-text/ids-text'),
       await import('ids-enterprise-wc/components/ids-hyperlink/ids-hyperlink'),
       await import('ids-enterprise-wc/components/ids-card/ids-card'),
+      await import('ids-enterprise-wc/components/ids-theme-switcher/ids-theme-switcher'),
       await import('ids-enterprise-wc/components/ids-block-grid/ids-block-grid'),
       await import('ids-enterprise-wc/components/ids-layout-grid/ids-layout-grid'),
       await import('ids-enterprise-wc/components/ids-container/ids-container')
@@ -15,6 +17,9 @@
   });
 </script>
 
-<ids-container>
+<ids-container padding="8">
+  {#if $appStore.allowThemeSwitcher}
+    <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
+  {/if}
   <slot></slot>
 </ids-container>

--- a/sveltekit-ids-wc/src/routes/data/[id].ts
+++ b/sveltekit-ids-wc/src/routes/data/[id].ts
@@ -1,0 +1,29 @@
+import fs from 'fs/promises';
+
+export async function get({ params }) {
+  console.log('Loading data from file:', `static/data/${params.id}.json`);
+  let item;
+
+  try {
+    item = await fs.readFile(`static/data/${params.id}.json`, 'utf-8');
+  } catch (e) {
+    return {
+      status: 404,
+      error: `Endpoint with ID "${params.id}" was not available`
+    }
+  }
+
+  if (!item) {
+    return {
+      status: 404,
+      error: `Endpoint with ID "${params.id}" was not available`
+    }
+  }
+
+  item = JSON.parse(item);
+
+  return {
+    status: 200,
+    body: item
+  }
+}

--- a/sveltekit-ids-wc/src/routes/ids-color/example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-color/example.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  onMount(async (): Promise<void> => {
+    await import('ids-enterprise-wc/components/ids-color/ids-color');
+  });
+</script>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">Color Swatch</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-color hex=""></ids-color>
+  <ids-color hex="#000000"></ids-color>
+  <ids-color hex="#C2A1F1" class="light" checked></ids-color>
+  <ids-color hex="#3B1470" class="dark" checked></ids-color>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">Color Swatch Outlined</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-color hex="" class="outlined"></ids-color>
+  <ids-color hex="#000000" class="outlined"></ids-color>
+  <ids-color hex="#C2A1F1" class="outlined light" checked></ids-color>
+  <ids-color hex="#3B1470" class="outlined dark" checked></ids-color>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">Disabled Color Swatch with Tooltip</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-color hex="" tooltip="black" disabled></ids-color>
+  <ids-color hex="#000000" tooltip="black" disabled></ids-color>
+  <ids-color hex="#C2A1F1" tooltip="black" class="light" disabled checked></ids-color>
+  <ids-color hex="#3B1470" tooltip="black" class="dark" disabled checked></ids-color>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">Color Swatch with Tooltip</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-color hex="" tooltip="black"></ids-color>
+  <ids-color hex="#000000" tooltip="black"></ids-color>
+  <ids-color hex="#C2A1F1" tooltip="black" class="light" checked></ids-color>
+  <ids-color hex="#3B1470" tooltip="black" class="dark" checked></ids-color>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">Outlined Color Swatch with Tooltip</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-color hex="" tooltip="black" class="outlined"></ids-color>
+  <ids-color hex="#000000" tooltip="black" class="outlined"></ids-color>
+  <ids-color hex="#C2A1F1" tooltip="black" class="outlined light" checked></ids-color>
+  <ids-color hex="#3B1470" tooltip="black" class="outlined dark" checked></ids-color>
+</ids-layout-grid>
+
+
+<!-- Color Picker Sizes -->
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">Color Swatch - Extra Small</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-color hex="" class="outlined" size="xs"></ids-color>
+  <ids-color hex="#941E1E" class="outlined" size="xs"></ids-color>
+  <ids-color hex="#C2A1F1" class="outlined light" checked size="xs"></ids-color>
+  <ids-color hex="#3B1470" class="outlined dark" checked size="xs"></ids-color>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">Color Swatch - Small</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-color hex="" class="outlined" size="sm"></ids-color>
+  <ids-color hex="#941E1E" class="outlined" size="sm"></ids-color>
+  <ids-color hex="#C2A1F1" class="outlined light" checked size="sm"></ids-color>
+  <ids-color hex="#3B1470" class="outlined dark" checked size="sm"></ids-color>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">Color Swatch - Small-Medium</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-color hex="" class="outlined" size="mm"></ids-color>
+  <ids-color hex="#941E1E" class="outlined" size="mm"></ids-color>
+  <ids-color hex="#C2A1F1" class="outlined light" checked size="mm"></ids-color>
+  <ids-color hex="#3B1470" class="outlined dark" checked size="mm"></ids-color>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">Color Swatch - Medium</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-color hex="" class="outlined" size="md"></ids-color>
+  <ids-color hex="#941E1E" class="outlined" size="md"></ids-color>
+  <ids-color hex="#C2A1F1" class="outlined light" checked size="md"></ids-color>
+  <ids-color hex="#3B1470" class="outlined dark" checked size="md"></ids-color>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">Color Swatch - Large</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid>
+  <ids-color hex="" class="outlined" size="lg"></ids-color>
+  <ids-color hex="#941E1E" class="outlined" size="lg"></ids-color>
+  <ids-color hex="#C2A1F1" class="outlined light" checked size="lg"></ids-color>
+  <ids-color hex="#3B1470" class="outlined dark" checked size="lg"></ids-color>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-color/index.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-color/index.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import IdsDemoListing from '../../components/demo/IdsDemoListing.svelte';
+
+  const listingData = [
+    {
+      link: 'example',
+      type: 'Main Example',
+      description: 'Shows color swatches'
+    }
+  ];
+</script>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="20" type="h1">Ids Color Examples</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <IdsDemoListing data={listingData} componentName="ids-color"></IdsDemoListing>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-dropdown/dynamic-example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-dropdown/dynamic-example.svelte
@@ -15,7 +15,9 @@
 </script>
 
 <ids-layout-grid auto="true">
-  <ids-text font-size="12" type="h1">IDS Dropdown (Imported into Svelte)</ids-text>
+  <ids-layout-grid-cell>
+    <ids-text font-size="12" type="h1">IDS Dropdown (Imported into Svelte)</ids-text>
+  </ids-layout-grid-cell>
 </ids-layout-grid>
 
 <ids-layout-grid auto="true">

--- a/sveltekit-ids-wc/src/routes/ids-dropdown/dynamic-example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-dropdown/dynamic-example.svelte
@@ -6,7 +6,7 @@
   import IdsListBox from '../../components/ids-list-box/IdsListBox.svelte';
   import IdsListBoxOption from '../../components/ids-list-box/IdsListBoxOption.svelte';
 
-  let ref;
+  let ref: IdsDropdown;
 
   onMount(async () => {
     // Highlights "California" in the Listbox

--- a/sveltekit-ids-wc/src/routes/ids-dropdown/example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-dropdown/example.svelte
@@ -1,8 +1,17 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { writable } from 'svelte/store';
+  import type { Writable } from 'svelte/store';
+
+  let ajaxItems: Writable<Array<{ id: string, name: string }>> = writable([]);
 
   onMount(async (): Promise<void> => {
     await import('ids-enterprise-wc/components/ids-dropdown/ids-dropdown');
+
+    // Populates the AJAX Dropdown
+    const res = await fetch('/data/states');
+    const json = await res.json();
+    $ajaxItems = json;
   });
 </script>
 
@@ -59,6 +68,97 @@
         <ids-list-box-option id="wv" value="wv">West Virginia</ids-list-box-option>
         <ids-list-box-option id="wi" value="wi">Wisconsin</ids-list-box-option>
         <ids-list-box-option id="wy" value="wy">Wyoming</ids-list-box-option>
+      </ids-list-box>
+    </ids-dropdown>
+
+    <ids-dropdown id="dropdown-2" readonly="true" label="Readonly Dropdown" value="opt3">
+      <ids-list-box>
+        <ids-list-box-option value="opt1" id="opt1-d2">Option One</ids-list-box-option>
+        <ids-list-box-option value="opt2" id="opt2-d2">Option Two</ids-list-box-option>
+        <ids-list-box-option value="opt3" id="opt3-d2">Option Three</ids-list-box-option>
+        <ids-list-box-option value="opt4" id="opt4-d2">Option Four</ids-list-box-option>
+        <ids-list-box-option value="opt5" id="opt5-d2">Option Five</ids-list-box-option>
+        <ids-list-box-option value="opt6" id="opt6-d2">Option Six</ids-list-box-option>
+      </ids-list-box>
+    </ids-dropdown>
+
+    <ids-dropdown id="dropdown-3" disabled="true" label="Disabled Dropdown" value="opt4">
+      <ids-list-box>
+        <ids-list-box-option value="opt1" id="opt1-d3">Option One</ids-list-box-option>
+        <ids-list-box-option value="opt2" id="opt2-d3">Option Two</ids-list-box-option>
+        <ids-list-box-option value="opt3" id="opt3-d3">Option Three</ids-list-box-option>
+        <ids-list-box-option value="opt4" id="opt4-d3">Option Four</ids-list-box-option>
+        <ids-list-box-option value="opt5" id="opt5-d3">Option Five</ids-list-box-option>
+        <ids-list-box-option value="opt6" id="opt6-d3">Option Six</ids-list-box-option>
+      </ids-list-box>
+    </ids-dropdown>
+
+    <ids-dropdown id="dropdown-4" label="Required Dropdown" value="opt1" validate="required">
+      <ids-list-box>
+        <ids-list-box-option value="blank" id="blank" aria-label="Blank"></ids-list-box-option>
+        <ids-list-box-option value="opt1" id="opt1-d4">Option One</ids-list-box-option>
+        <ids-list-box-option value="opt2" id="opt2-d4">Option Two</ids-list-box-option>
+        <ids-list-box-option value="opt3" id="opt3-d4">Option Three</ids-list-box-option>
+        <ids-list-box-option value="opt4" id="opt4-d4">Option Four</ids-list-box-option>
+        <ids-list-box-option value="opt5" id="opt5-d4">Option Five</ids-list-box-option>
+        <ids-list-box-option value="opt6" id="opt6-d4">Option Six</ids-list-box-option>
+      </ids-list-box>
+    </ids-dropdown>
+
+    <ids-dropdown id="dropdown-5" label="Dropdown with Icons" value="opt2">
+      <ids-list-box>
+        <ids-list-box-option value="opt1" id="opt1-d5">
+          <ids-icon icon="user-profile"></ids-icon>
+          <span>Option One</span>
+        </ids-list-box-option>
+        <ids-list-box-option value="opt2" id="opt2-d5">
+          <ids-icon icon="project"></ids-icon>
+          <span>Option Two</span>
+        </ids-list-box-option>
+        <ids-list-box-option value="opt3" id="opt3-d5">
+          <ids-icon icon="purchasing"></ids-icon>
+          <span>Option Three</span>
+        </ids-list-box-option>
+        <ids-list-box-option value="opt4" id="opt4-d5">
+          <ids-icon icon="quality"></ids-icon>
+          <span>Option Four</span></ids-list-box-option>
+        <ids-list-box-option value="opt5" id="opt5-d5">
+          <ids-icon icon="rocket"></ids-icon>
+          <span>Option Five</span>
+        </ids-list-box-option>
+        <ids-list-box-option value="opt6" id="opt6-d5">
+          <ids-icon icon="roles"></ids-icon>
+          <span>Option Six</span>
+        </ids-list-box-option>
+      </ids-list-box>
+    </ids-dropdown>
+
+    <ids-dropdown id="dropdown-6" label="Dropdown with Tooltips" tooltip="Additional Info" value="opt2">
+      <ids-list-box>
+        <ids-list-box-option value="opt1" id="opt1-d6" tooltip="Additional Info on Option One">Option One</ids-list-box-option>
+        <ids-list-box-option value="opt2" id="opt2-d6" tooltip="Additional Info on Option Two">Option Two</ids-list-box-option>
+        <ids-list-box-option value="opt3" id="opt3-d6" tooltip="Additional Info on Option Three">Option Three</ids-list-box-option>
+        <ids-list-box-option value="opt4" id="opt4-d6" tooltip="Additional Info on Option Four">Option Four</ids-list-box-option>
+        <ids-list-box-option value="opt5" id="opt5-d6" tooltip="Additional Info on Option Five">Option Five</ids-list-box-option>
+        <ids-list-box-option value="opt6" id="opt6-d6" tooltip="Additional Info on Option Six">Option Six</ids-list-box-option>
+      </ids-list-box>
+    </ids-dropdown>
+
+    <ids-dropdown id="dropdown-7" label="Dropdown Using Ajax" value="ak">
+      <ids-list-box>
+        {#each $ajaxItems as item}
+          <ids-list-box-option id={item.id} value={item.id}>{item.name}</ids-list-box-option>
+        {/each}
+      </ids-list-box>
+    </ids-dropdown>
+
+    <ids-dropdown id="dropdown-8" label="Dropdown with Allow Blank" allow-blank>
+      <ids-list-box>
+        <ids-list-box-option value="opt1" id="opt1-d8">
+          <span>Option One</span>
+        </ids-list-box-option>
+        <ids-list-box-option value="opt2" id="opt2-d8">
+          <span>Option Two</span>
       </ids-list-box>
     </ids-dropdown>
   </ids-layout-grid-cell>

--- a/sveltekit-ids-wc/src/routes/ids-hyperlink/dynamic-example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-hyperlink/dynamic-example.svelte
@@ -17,7 +17,7 @@
 
   // Prevents any real navigation from occuring,
   // but logs the hyperlink's target URL if it's set
-  const handleClick = (e: CustomEvent): any => {
+  const handleClick = (e: MouseEvent): any => {
     e.preventDefault();
     const target = (e.target as unknown as IdsHyperLink);
 

--- a/sveltekit-ids-wc/src/routes/ids-hyperlink/dynamic-example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-hyperlink/dynamic-example.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import IdsHyperLink from '../../components/ids-hyperlink/IdsHyperLink.svelte';
+  import type IdsButton from '../../components/ids-button/IdsButton.svelte';
+
+  let ref: IdsHyperLink;
+
+  // Generates the buttons with linking information
+  const links = [
+    { href: 'https://www.infor.com', buttonText: 'Use Infor.com', linkText: 'Open Infor.com!' },
+    { href: 'https://www.google.com', buttonText: 'Use Google', linkText: 'Open Google!' },
+    { href: 'https://www.duckduckgo.com', buttonText: 'Use DuckDuckGo', linkText: 'Open DuckDuckGo!' },
+    { href: '', buttonText: 'Do nothing', linkText: 'Goes Nowhere' }
+  ]
+  const getLastLink = () => links[links.length - 1];
+
+  let displayedHyperlinkText = getLastLink().linkText;
+
+  // Prevents any real navigation from occuring,
+  // but logs the hyperlink's target URL if it's set
+  const handleClick = (e: CustomEvent): any => {
+    e.preventDefault();
+    const target = (e.target as unknown as IdsHyperLink);
+
+    if (target.href) {
+      console.info(`Clicked hyperlink will go to ${target.href}`);
+    } else {
+      console.info(`Clicked hyperlink will go nowhere`);
+    }
+  }
+
+  const handleHrefChange = (e: CustomEvent): any => {
+    const target = (e.target as unknown as IdsButton); // IdsButton
+    if (ref && target) {
+      ref.href = target.dataset.href;
+      displayedHyperlinkText = target.dataset.linkText;
+    }
+  }
+</script>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <ids-text font-size="12" type="h1">IdsHyperlink (Svelte Component)</ids-text>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <ids-text>Use the buttons below to set a URL on the link before clicking. <br/>
+    Using the link won't cause the page to change, but the URL will be logged to the console.</ids-text>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <IdsHyperLink
+      textDecoration="hover"
+      bind:this={ref}
+      on:click={handleClick}>{ displayedHyperlinkText }</IdsHyperLink>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    {#each links as link}
+      <ids-button 
+        type="secondary"
+        data-href={link.href}
+        data-link-text={link.linkText}
+        on:click={handleHrefChange}>{link.buttonText}</ids-button>&nbsp;
+    {/each}
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-hyperlink/example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-hyperlink/example.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import TAG_COLORS from '../../components/ids-tag/colors';
+  import { onMount } from 'svelte';
+
+  onMount(async (): Promise<void> => {
+    await import('ids-enterprise-wc/components/ids-hyperlink/ids-hyperlink');
+  });
+</script>
+
+<style></style>
+
+<ids-layout-grid auto="true">
+  <ids-text type="h1" font-size="12">IDS Hyperlink (Imported into Svelte)</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h2">Hyperlink</ids-text>
+</ids-layout-grid>
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <ids-hyperlink href="http://www.example.com" target="_blank">Normal Link</ids-hyperlink>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h2">Hyperlink (disabled)</ids-text>
+</ids-layout-grid>
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <ids-hyperlink href="http://www.example.com" disabled="true" target="_blank">Disabled Link</ids-hyperlink>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h2">Hyperlink (tabindex)</ids-text>
+</ids-layout-grid>
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <ids-hyperlink href="http://www.example.com" tabindex="-1">Not Tabbable Link</ids-hyperlink>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-hyperlink/index.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-hyperlink/index.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import IdsDemoListing from '../../components/demo/IdsDemoListing.svelte';
+
+  const listingData = [
+    {
+      link: 'example',
+      type: 'Main Example',
+      description: 'Simple usage of an IDS HyperLink within Svelte'
+    },
+    {
+      link: 'dynamic-example',
+      type: 'Dynamic Example',
+      description: 'IDS HyperLink wrapped in a Svelte component'
+    }
+  ];
+</script>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="20" type="h1">Ids HyperLink Examples</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <IdsDemoListing data={listingData} componentName="ids-hyperlink"></IdsDemoListing>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-icon/example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-icon/example.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  const iconData = [
+    'alert-solid',
+    'back-color',
+    'filter',
+    'settings',
+    'update-preview'
+  ];
+
+  const emptyMessageIconData = [
+    'empty-error-loading',
+    'empty-generic',
+    'empty-new-project'
+  ];
+
+  onMount(async (): Promise<void> => {
+    await import('ids-enterprise-wc/components/ids-icon/ids-icon');
+  });
+</script>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">Icons</ids-text>
+</ids-layout-grid>
+<ids-layout-grid class="ids-icon-list" auto="true" gap="md">
+  {#each iconData as icon}
+    <span class="ids-icon-container">
+      <ids-text font-size="10">icon-{icon}</ids-text>
+      <br />
+      <ids-icon icon={icon} size="large"></ids-icon>
+      <ids-icon icon={icon}></ids-icon>
+      <ids-icon icon={icon} size="xsmall"></ids-icon>
+    </span>
+  {/each}
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">Empty Message Icons</ids-text>
+</ids-layout-grid>
+<ids-layout-grid class="ids-empty-icon-list" auto="true" gap="md">
+  {#each emptyMessageIconData as icon}
+    <span class="ids-icon-container">
+      <ids-text font-size="10">icon-{icon}</ids-text>
+      <br />
+      <ids-icon icon={icon} height="80" width="80" viewBox="0 0 80 80"></ids-icon>
+    </span>
+  {/each}
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-icon/index.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-icon/index.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import IdsDemoListing from '../../components/demo/IdsDemoListing.svelte';
+
+  const listingData = [
+    {
+      link: 'example',
+      type: 'Main Example',
+      description: 'Shows icons'
+    }
+  ];
+</script>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="20" type="h1">Ids Icon Examples</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <IdsDemoListing data={listingData} componentName="ids-icon"></IdsDemoListing>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-mask/example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-mask/example.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  onMount(async (): Promise<void> => {
+    await import('ids-enterprise-wc/components/ids-input/ids-input');
+
+    // Phone Number Input - standard pattern mask
+    const phoneInput: any = document.querySelector('#mask-phone-number');
+    if (!phoneInput) return;
+    phoneInput.mask = ['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/];
+
+    // Date Input - use `date` string to pre-configure the internal Date Mask
+    const dateInput: any = document.querySelector('#mask-date');
+    dateInput.mask = 'date';
+    dateInput.maskOptions = {
+      format: 'M/d/yyyy hh:mm a'
+    };
+
+    // Number Input - use `number` string to pre-configure the internal Number Mask
+    const numberInput: any = document.querySelector('#mask-number');
+    numberInput.mask = 'number';
+    numberInput.maskOptions = {
+      allowDecimal: true,
+      allowNegative: true,
+      allowThousandsSeparator: true,
+      decimalLimit: 2,
+      integerLimit: 7
+    };
+  });
+</script>
+
+<style></style>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">IDS Inputs with Masks (Imported into Svelte)</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid cols="3" gap="md">
+  <ids-layout-grid-cell>
+    <ids-input id="mask-phone-number" label="Phone Number"
+      placeholder="(###) ###-####"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-date" label="Date/Time"
+      placeholder="M/d/yyyy hh:mm a"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number" label="Formatted Number"
+      placeholder="-1,000,000.00" text-align="end"></ids-input>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-mask/index.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-mask/index.svelte
@@ -8,24 +8,24 @@
       description: 'Simple usage of an IDS Input within Svelte'
     },
     {
-      link: 'dynamic-example',
-      type: 'Dynamic Example',
-      description: 'IDS Input wrapped in a Svelte component'
+      link: 'localized-dates',
+      type: 'Date Localization Example',
+      description: 'IDS Date Masked Input using the current Locale'
     },
     {
-      link: 'masks',
-      type: 'Mask Example',
-      description: 'Demonstrates masked fields when used with Svelte'
+      link: 'localized-numbers',
+      type: 'Number Localization Example',
+      description: 'IDS Number Masked Input using the current Locale'
     }
   ];
 </script>
 
 <ids-layout-grid auto="true">
-  <ids-text font-size="20" type="h1">Ids Input Examples</ids-text>
+  <ids-text font-size="20" type="h1">Ids Mask Examples</ids-text>
 </ids-layout-grid>
 
 <ids-layout-grid auto="true">
   <ids-layout-grid-cell>
-    <IdsDemoListing data={listingData} componentName="ids-input"></IdsDemoListing>
+    <IdsDemoListing data={listingData} componentName="ids-mask"></IdsDemoListing>
   </ids-layout-grid-cell>
 </ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-mask/localized-dates.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-mask/localized-dates.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  onMount(async () => {
+    await import('ids-enterprise-wc/components/ids-input/ids-input');
+
+    const pageContainer: any = document.querySelector('ids-container');
+    let calendar = pageContainer.locale.calendar();
+
+    // Configure Short Date input
+    const dateInputShort: any = document.querySelector('#mask-date-short');
+    dateInputShort.mask = 'date';
+    dateInputShort.placeholder = dateInputShort.maskOptions.format;
+
+    // The default date format absorbed by the Mask Mixin from IdsLocale is "short".
+    // For the timestamp field, we have to manually override the format set by the mixin.
+    const dateInputTime: any = document.querySelector('#mask-date-time');
+    dateInputTime.mask = 'date';
+    dateInputTime.maskOptions = {
+      format: calendar.dateFormat.timestamp
+    };
+    dateInputTime.placeholder = dateInputTime.maskOptions.format;
+
+    // Change locale on the date input when the Page container's locale changes
+    pageContainer.addEventListener('localechange', () => {
+      calendar = pageContainer.locale.calendar();
+      const shortFormat = calendar.dateFormat.short;
+      const timeFormat = calendar.dateFormat.timestamp;
+
+      dateInputShort.value = '';
+      dateInputShort.maskOptions.format = shortFormat;
+      dateInputShort.placeholder = dateInputShort.maskOptions.format;
+
+      dateInputTime.value = '';
+      dateInputTime.maskOptions.format = timeFormat;
+      dateInputTime.placeholder = dateInputTime.maskOptions.format;
+    });
+  });
+</script>
+
+<ids-layout-grid cols="3" gap="md">
+  <ids-layout-grid-cell>
+    <ids-text font-size="12" type="h1">Masked Inputs (Localized Dates)</ids-text>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid cols="3" gap="md">
+  <ids-layout-grid-cell>
+    <ids-input id="mask-date-short" size="sm" label="Short Date"></ids-input>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid cols="3" gap="md">
+  <ids-layout-grid-cell>
+    <ids-input id="mask-date-time" size="sm" label="Timestamp"></ids-input>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-mask/localized-numbers.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-mask/localized-numbers.svelte
@@ -1,0 +1,256 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { deepClone } from '../../utils/deepClone';
+
+  onMount(async () => {
+    await import('ids-enterprise-wc/components/ids-input/ids-input');
+
+    const pageContainer: any = document.querySelector('ids-container');
+    // const dropdown: any = document.querySelector('ids-dropdown');
+
+    // Uses the defined integer/decimal limits to create an IdsInput
+    // `placeholder` definition based on the actual length of the mask.
+    const createPlaceholder = (input: any) => {
+      const ints = input.maskOptions.integerLimit;
+      const decs = input.maskOptions.decimalLimit || 0;
+      let placeholder = '';
+
+      for (let i = 0; i < ints; i++) {
+        placeholder += '1';
+      }
+
+      if (input.maskOptions.allowDecimal) {
+        placeholder += input.maskOptions?.symbols?.decimal || '.';
+        for (let i = 0; i < decs; i++) {
+          placeholder += '1';
+        }
+      }
+
+      // calling `input.mask()` directly doesn't include the locale,
+      // since it's normally added by the IdsInput
+      const opts = deepClone(input.maskOptions);
+      opts.locale = input.locale;
+      const maskArray = input.mask(placeholder, opts).mask;
+
+      // Write a placeholder string based on a slightly-modified mask array
+      // (removes "[]"" caret traps and replaces regex matchers with "#")
+      input.placeholder = `${maskArray.map((el: any) => {
+        if (typeof el !== 'string') {
+          return '#';
+        }
+        if (el === '[]') {
+          return '';
+        }
+        return el;
+      }).join('')}`;
+    };
+
+    // ===================================================
+    // Set basic rules on all input fields
+    const allInputs: Array<any> = [...document.querySelectorAll('ids-input')];
+    allInputs.forEach((input) => {
+      input.textAlign = 'end';
+      input.mask = 'number';
+    });
+
+    const allNegativeInputs: Array<any> = [...document.querySelectorAll('[id*="negative"]')];
+    allNegativeInputs.forEach((input) => {
+      input.maskOptions.allowNegative = true;
+    });
+
+    const allDecimalInputs: Array<any> = [...document.querySelectorAll('[id*="decimal"]')];
+    allDecimalInputs.forEach((input) => {
+      input.maskOptions.allowDecimal = true;
+      input.maskOptions.decimalLimit = 2;
+    });
+
+    const allGroupInputs: Array<any> = [...document.querySelectorAll('[id*="group"]')];
+    allGroupInputs.forEach((input) => {
+      input.maskOptions.allowThousandsSeparator = true;
+    });
+
+    // ===================================================
+    // Set limits on "thousands-length" inputs
+    const allThousandsInputs: Array<any> = [...document.querySelectorAll('[id*="thousands"]')];
+    allThousandsInputs.forEach((input) => {
+      input.maskOptions.integerLimit = 4;
+      createPlaceholder(input);
+    });
+
+    // Set limits on "millions-length" inputs
+    const allMillionsInputs: Array<any> = [...document.querySelectorAll('[id*="millions"]')];
+    allMillionsInputs.forEach((input) => {
+      input.maskOptions.integerLimit = 7;
+      createPlaceholder(input);
+    });
+
+    // Set limits on "billions-length" inputs
+    const allBillionsInputs: Array<any> = [...document.querySelectorAll('[id*="billions"]')];
+    allBillionsInputs.forEach((input) => {
+      input.maskOptions.integerLimit = 10;
+      createPlaceholder(input);
+    });
+
+    // Set limits on "quintillions-length" inputs
+    const allQuintillionsInputs: Array<any> = [...document.querySelectorAll('[id*="quintillions"]')];
+    allQuintillionsInputs.forEach((input) => {
+      input.maskOptions.integerLimit = 18;
+      if (input.id.includes('decimal')) {
+        input.maskOptions.decimalLimit = 6;
+      }
+      createPlaceholder(input);
+    });
+
+    /*
+    // ===================================================
+    // Change the IdsContainer's locale setting when the dropdown is modified
+    dropdown.addEventListener('change', async (e: any) => {
+      await pageContainer.setLocale(e.target.value);
+    });
+    */
+
+    // Change localized strings on all number inputs when the Page container's locale changes
+    pageContainer.addEventListener('localechange', () => {
+      allInputs.forEach((input) => {
+        input.value = '';
+        createPlaceholder(input);
+      });
+    });
+  });
+</script>
+
+<ids-layout-grid cols="3" gap="md">
+  <ids-layout-grid-cell>
+    <ids-text font-size="12" type="h1">Masked Inputs (Localized Numbers) (Imported into Svelte)</ids-text>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<!-- Thousands-length Inputs without groups -->
+<ids-layout-grid cols="4" gap="md">
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-thousands" label="Thousands"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-thousands-negative" label="Thousands + Negative"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-thousands-decimal" label="Thousands + Decimal"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-thousands-decimal-negative" label="Thousands + Decimal + Negative"></ids-input>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<!-- Thousands-length Inputs with groups -->
+<ids-layout-grid cols="4" gap="md">
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-thousands" label="Thousands + Groups"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-thousands-negative" label="Thousands + Groups + Negative"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-thousands-decimal" label="Thousands + Groups + Decimal"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-thousands-decimal-negative" label="Thousands + Groups + Decimal + Negative"></ids-input>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<!-- Millions-length Inputs without groups -->
+<ids-layout-grid cols="4" gap="md">
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-millions" label="Millions"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-millions-negative" label="Millions + Negative"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-millions-decimal" label="Millions + Decimal"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-millions-decimal-negative" label="Millions + Decimal + Negative"></ids-input>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<!-- Millions-length Inputs with groups -->
+<ids-layout-grid cols="4" gap="md">
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-millions" label="Millions + Groups"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-millions-negative" label="Millions + Groups + Negative"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-millions-decimal" label="Millions + Groups + Decimal"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-millions-decimal-negative" label="Millions + Groups + Decimal + Negative"></ids-input>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<!-- Billions-length Inputs without groups -->
+<ids-layout-grid cols="4" gap="md">
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-billions" label="Billions"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-billions-negative" label="Billions + Negative"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-billions-decimal" label="Billions + Decimal"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-billions-decimal-negative" label="Billions + Decimal + Negative"></ids-input>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<!-- Billions-length Inputs with groups -->
+<ids-layout-grid cols="4" gap="md">
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-billions" label="Billions + Groups"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-billions-negative" label="Billions + Groups + Negative"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-billions-decimal" label="Billions + Groups + Decimal"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-billions-decimal-negative" label="Billions + Groups + Decimal + Negative">
+    </ids-input>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<!-- Quintillions-length Inputs without groups -->
+<ids-layout-grid cols="4" gap="md">
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-quintillions" label="Quintillions"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-quintillions-negative" label="Quintillions + Negative"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-quintillions-decimal" label="Quintillions + Decimal"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-quintillions-decimal-negative" label="Quintillions + Decimal + Negative"></ids-input>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<!-- Quintillions-length Inputs with groups -->
+<ids-layout-grid cols="4" gap="md">
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-quintillions" label="Quintillions + Groups"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-quintillions-negative" label="Quintillions + Groups + Negative"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-quintillions-decimal" label="Quintillions + Groups + Decimal"></ids-input>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-input id="mask-number-groups-quintillions-decimal-negative" label="Quintillions + Groups + Decimal + Negative">
+    </ids-input>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-modal/example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-modal/example.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  onMount(async (): Promise<void> => {
+    await Promise.all([
+      import('ids-enterprise-wc/components/ids-modal/ids-modal'),
+      import('ids-enterprise-wc/components/ids-modal-button/ids-modal-button')
+    ]);
+
+    const triggerId = '#modal-trigger-btn';
+    const triggerBtn: any = document.querySelector(triggerId);
+    const modal: any = document.querySelector('ids-modal');
+
+    // Links the Modal to its trigger button (sets up click/focus events)
+    modal.target = triggerBtn;
+    modal.trigger = 'click';
+
+    // Disable the trigger button when showing the Modal.
+    modal.addEventListener('beforeshow', () => {
+      triggerBtn.disabled = true;
+      return true;
+    });
+
+    // Close the modal when its inner button is clicked.
+    modal.onButtonClick = () => {
+      modal.hide();
+    };
+
+    // After the modal is done hiding, re-enable its trigger button.
+    modal.addEventListener('hide', () => {
+      triggerBtn.disabled = false;
+    });
+  });
+</script>
+
+<ids-modal id="my-modal" aria-labelledby="my-modal-title">
+  <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
+  <ids-modal-button slot="buttons" id="modal-close-btn" type="primary">
+    <span slot="text">OK</span>
+  </ids-modal-button>
+  <ids-text text-align="start">This is an active IDS Modal component</ids-text>
+</ids-modal>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">IDS Modal (Imported into Svelte)</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <ids-button id="modal-trigger-btn" type="secondary">
+      <span slot="text">Trigger a Modal</span>
+    </ids-button>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-modal/index.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-modal/index.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import IdsDemoListing from '../../components/demo/IdsDemoListing.svelte';
+
+  const listingData = [
+    {
+      link: 'example',
+      type: 'Main Example',
+      description: 'Simple usage of an IDS Modal within Svelte'
+    }
+  ];
+</script>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="20" type="h1">Ids Modal Examples</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <IdsDemoListing data={listingData} componentName="ids-modal"></IdsDemoListing>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-popup-menu/example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-popup-menu/example.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  let ref;
+
+  onMount(async (): Promise<void> => {
+    await import('ids-enterprise-wc/components/ids-popup-menu/ids-popup-menu');
+    if (ref && ref.popupEl) {
+      console.dir(ref.popupEl)
+      ref.popupEl.align = 'top, left';
+    }
+  });
+
+  const handleSelected = (e: CustomEvent) => {
+    console.info(`Item "${e.detail.elem.text}" was selected`);
+  };
+
+  $: {
+    // Set defaults on the ref
+    if (ref && ref.popupEl) {
+      ref.popupEl.align = 'top, left';
+    }
+  }
+</script>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <ids-text font-size="12" type="h1">Popup Menu (Imported into Svelte)</ids-text>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <ids-text>Right click anywhere to open the Popupmenu</ids-text>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-popup-menu
+  id="popupmenu" 
+  bind:this={ref}
+  on:selected={handleSelected}>
+  <ids-menu-group>
+    <ids-menu-item>Item One</ids-menu-item>
+    <ids-menu-item>Item Two</ids-menu-item>
+    <ids-menu-item>Item Three</ids-menu-item>
+    <ids-menu-item>Item Four</ids-menu-item>
+    <ids-separator></ids-separator>
+    <ids-menu-item id="item-five">
+      More Actions
+      <ids-popup-menu>
+        <ids-menu-group>
+          <ids-menu-item>Sub-item One</ids-menu-item>
+          <ids-menu-item>Sub-item Two</ids-menu-item>
+          <ids-menu-item>Sub-item Three</ids-menu-item>
+        </ids-menu-group>
+      </ids-popup-menu>
+    </ids-menu-item>
+    <ids-menu-item id="item-six">
+      Even More Actions
+      <ids-popup-menu>
+        <ids-menu-group>
+          <ids-menu-item icon="settings">
+            Change Settings
+            <ids-popup-menu>
+              <ids-menu-group>
+                <ids-menu-item>Setting One</ids-menu-item>
+                <ids-menu-item>Setting Two</ids-menu-item>
+                <ids-menu-item>Setting Three</ids-menu-item>
+                <ids-menu-item>REAAAAALLLLY Long Setting Number Four</ids-menu-item>
+              </ids-menu-group>
+            </ids-popup-menu>
+          </ids-menu-item>
+          <ids-menu-item icon="mail">Send Mail</ids-menu-item>
+          <ids-menu-item icon="filter">Filter Content</ids-menu-item>
+        </ids-menu-group>
+      </ids-popup-menu>
+    </ids-menu-item>
+  </ids-menu-group>
+</ids-popup-menu>

--- a/sveltekit-ids-wc/src/routes/ids-popup-menu/index.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-popup-menu/index.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import IdsDemoListing from '../../components/demo/IdsDemoListing.svelte';
+
+  const listingData = [
+    {
+      link: 'example',
+      type: 'Main Example',
+      description: 'Simple usage of an IDS Popup Menu within Svelte'
+    },
+    {
+      link: 'dynamic-example',
+      type: 'Dynamic Example',
+      description: 'IDS Popup Menu wrapped in a Svelte component, driven by a Svelte custom store'
+    }
+  ];
+</script>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="20" type="h1">Ids Popup Menu Examples</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <IdsDemoListing data={listingData} componentName="ids-popup-menu"></IdsDemoListing>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-swaplist/example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-swaplist/example.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { writable } from 'svelte/store';
+  import type { Writable } from 'svelte/store';
+
+  let ref;
+  let ajaxItems: Writable<Array<{ id: string, name: string }>> = writable([]);
+
+  onMount(async (): Promise<void> => {
+    await import('ids-enterprise-wc/components/ids-swaplist/ids-swaplist');
+
+    // Populates the AJAX Dropdown
+    const res = await fetch('/data/periods');
+    const json = await res.json();
+    $ajaxItems = json;
+  });
+
+  // When loading an IdsSwaplist:
+  // - Use a `bind:this={ref}` on the IdsSwaplist host element.
+  // - Use `onMount` to populate from a data source.
+  // - Use a reactive statement (below) to set both the template and data.  
+  //   Using an inline template tag with variables may conflict with Svelte's template syntax.
+  $: {
+    if (ref) {
+      ref.defaultTemplate = '<ids-swappable-item><ids-text>${city}</ids-text></ids-swappable-item>';
+      if ($ajaxItems) {
+        ref.data = $ajaxItems
+      }
+    }
+  }
+</script>
+
+<ids-layout-grid>
+  <ids-text font-size="12" type="h1">SwapList</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+
+    <div id="status"></div>
+
+    {#if $ajaxItems.length}
+      <ids-swaplist id="swaplist-1" count="3" bind:this={ref}></ids-swaplist>
+    {/if}
+
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-swaplist/index.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-swaplist/index.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import IdsDemoListing from '../../components/demo/IdsDemoListing.svelte';
+
+  const listingData = [
+    {
+      link: 'example',
+      type: 'Main Example',
+      description: 'Simple usage of an IDS SwapList within Svelte'
+    }
+  ];
+</script>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="20" type="h1">Ids SwapList Examples</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <IdsDemoListing data={listingData} componentName="ids-swaplist"></IdsDemoListing>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-tabs/example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-tabs/example.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  onMount(async (): Promise<void> => {
+    await import('ids-enterprise-wc/components/ids-tabs/ids-tab');
+    await import('ids-enterprise-wc/components/ids-tabs/ids-tab-content');
+    await import('ids-enterprise-wc/components/ids-tabs/ids-tabs');
+    await import('ids-enterprise-wc/components/ids-tabs/ids-tabs-context');
+  });
+
+  const handleChange = (e: Event | CustomEvent | any) => {
+    console.info(`ids-tabs.on('change') =>`, e.target?.value);
+  };
+</script>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">Tabs</ids-text>
+</ids-layout-grid>
+
+<ids-tabs-context>
+  <ids-tabs>
+    <ids-tab value="contracts" on:change={handleChange}>Contracts</ids-tab>
+    <ids-tab value="opportunities" on:change={handleChange}>Opportunities</ids-tab>
+    <ids-tab value="attachments" disabled on:change={handleChange}>Attachments</ids-tab>
+    <ids-tab value="notes" on:change={handleChange}>Notes</ids-tab>
+  </ids-tabs>
+  <div class="ids-tabs-content">
+    <ids-tab-content value="contracts">
+      <ids-layout-grid auto="true">
+        <ids-text font-size="16" type="p">Facilitate cultivate monetize, seize e-services peer-to-peer content integrateAJAX-enabled user-centric strategize. Mindshare; repurpose integrate global addelivery leading-edge frictionless, harness real-time plug-and-play standards-compliant 24/7 enterprise strategize robust infomediaries: functionalities back-end. Killer disintermediate web-enabled ubiquitous empower relationships, solutions, metrics architectures.</ids-text>
+      </ids-layout-grid>
+    </ids-tab-content>
+    <ids-tab-content value="opportunities">
+      <div class="tab-content">
+        <ids-layout-grid auto="true">
+          <ids-text font-size="16" type="p">
+            Bricks-and-clicks? Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.
+          </ids-text>
+        </ids-layout-grid>
+      </div>
+    </ids-tab-content>
+    <ids-tab-content value="attachments">
+      <ids-layout-grid auto="true">
+        <ids-text font-size="16" type="p">
+          Frictionless webservices, killer open-source innovate, best-of-breed, whiteboard interactive back-end optimize capture dynamic front-end. Initiatives ubiquitous 24/7 enhance channels B2B drive frictionless web-readiness generate recontextualize widgets applications. Sexy sticky matrix, user-centred, rich user-centric: peer-to-peer podcasting networking addelivery optimize streamline integrated proactive: granular morph.
+        </ids-text>
+      </ids-layout-grid>
+    </ids-tab-content>
+    <ids-tab-content value="notes">
+      <ids-layout-grid auto="true">
+        <ids-text font-size="16" type="p">
+          Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.
+        </ids-text>
+      </ids-layout-grid>
+    </ids-tab-content>
+  </div>
+</ids-tabs-context>

--- a/sveltekit-ids-wc/src/routes/ids-tabs/header-tabs@fullpage.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-tabs/header-tabs@fullpage.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { appStore } from '../../app.store';
+
+  onMount(async (): Promise<void> => {
+    await Promise.all([
+      import('ids-enterprise-wc/components/ids-header/ids-header'),
+      import('ids-enterprise-wc/components/ids-toolbar/ids-toolbar'),
+      import('ids-enterprise-wc/components/ids-toolbar/ids-toolbar-section'),
+      import('ids-enterprise-wc/components/ids-tabs/ids-tab'),
+      import('ids-enterprise-wc/components/ids-tabs/ids-tab-content'),
+      import('ids-enterprise-wc/components/ids-tabs/ids-tabs'),
+      import('ids-enterprise-wc/components/ids-tabs/ids-tabs-context')
+    ]);
+  });
+
+  const handleChange = (e: Event | CustomEvent | any) => {
+    console.info(`ids-tabs.on('change') =>`, e.target?.value);
+  };
+</script>
+
+<ids-tabs-context>
+  <ids-header>
+    <ids-toolbar>
+      <ids-toolbar-section>
+        <ids-toolbar-section type="title">
+          <ids-text font-size="20" color-variant="alternate">Header Tabs</ids-text>
+          <ids-text font-size="14" color-variant="alternate">ids-tabs for an overall app header</ids-text>
+        </ids-toolbar-section>
+      </ids-toolbar-section>
+      <ids-toolbar-section type="buttonset" align="end">
+        {#if $appStore.allowThemeSwitcher}
+          <ids-theme-switcher mode="light" color-variant="alternate"></ids-theme-switcher>
+        {/if}
+      </ids-toolbar-section>
+    </ids-toolbar>
+    <ids-tabs value="opportunities" color-variant="alternate">
+      <ids-tab value="contracts" on:change={handleChange}>Contracts</ids-tab>
+      <ids-tab value="opportunities" on:change={handleChange}>Opportunities</ids-tab>
+      <ids-tab value="attachments" disabled on:change={handleChange}>Attachments</ids-tab>
+      <ids-tab value="notes" on:change={handleChange}>Notes</ids-tab>
+    </ids-tabs>
+  </ids-header>
+  <div class="ids-tabs-content">
+    <ids-tab-content value="contracts">
+      <ids-layout-grid auto="true">
+        <ids-text font-size="16" type="p">Facilitate cultivate monetize, seize e-services peer-to-peer content integrateAJAX-enabled user-centric strategize. Mindshare; repurpose integrate global addelivery leading-edge frictionless, harness real-time plug-and-play standards-compliant 24/7 enterprise strategize robust infomediaries: functionalities back-end. Killer disintermediate web-enabled ubiquitous empower relationships, solutions, metrics architectures.</ids-text>
+      </ids-layout-grid>
+    </ids-tab-content>
+    <ids-tab-content value="opportunities">
+      <div class="tab-content">
+        <ids-layout-grid auto="true">
+          <ids-text font-size="16" type="p">
+            Bricks-and-clicks? Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.
+          </ids-text>
+        </ids-layout-grid>
+      </div>
+    </ids-tab-content>
+    <ids-tab-content value="attachments">
+      <ids-layout-grid auto="true">
+        <ids-text font-size="16" type="p">
+          Frictionless webservices, killer open-source innovate, best-of-breed, whiteboard interactive back-end optimize capture dynamic front-end. Initiatives ubiquitous 24/7 enhance channels B2B drive frictionless web-readiness generate recontextualize widgets applications. Sexy sticky matrix, user-centred, rich user-centric: peer-to-peer podcasting networking addelivery optimize streamline integrated proactive: granular morph.
+        </ids-text>
+      </ids-layout-grid>
+    </ids-tab-content>
+    <ids-tab-content value="notes">
+      <ids-layout-grid auto="true">
+        <ids-text font-size="16" type="p">
+          Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.
+        </ids-text>
+      </ids-layout-grid>
+    </ids-tab-content>
+  </div>
+</ids-tabs-context>

--- a/sveltekit-ids-wc/src/routes/ids-tabs/index.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-tabs/index.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import IdsDemoListing from '../../components/demo/IdsDemoListing.svelte';
+
+  const listingData = [
+    {
+      link: 'example',
+      type: 'Main Example',
+      description: 'Simple usage of an IDS Tabs within Svelte'
+    },
+    {
+      link: 'header-tabs',
+      type: 'Example',
+      description: 'Shows header tabs'
+    },
+    {
+      link: 'module',
+      type: 'Example',
+      description: 'Shows module tabs'
+    },
+    {
+      link: 'vertical',
+      type: 'Example',
+      description: 'Shows vertical tabs'
+    }
+  ];
+</script>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="20" type="h1">Ids Tabs Examples</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <IdsDemoListing data={listingData} componentName="ids-text"></IdsDemoListing>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-tabs/module@fullpage.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-tabs/module@fullpage.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { appStore } from '../../app.store';
+
+  onMount(async (): Promise<void> => {
+    await Promise.all([
+      import('ids-enterprise-wc/components/ids-header/ids-header'),
+      import('ids-enterprise-wc/components/ids-toolbar/ids-toolbar'),
+      import('ids-enterprise-wc/components/ids-toolbar/ids-toolbar-section'),
+      import('ids-enterprise-wc/components/ids-tabs/ids-tab'),
+      import('ids-enterprise-wc/components/ids-tabs/ids-tab-content'),
+      import('ids-enterprise-wc/components/ids-tabs/ids-tab-more'),
+      import('ids-enterprise-wc/components/ids-tabs/ids-tabs'),
+      import('ids-enterprise-wc/components/ids-tabs/ids-tabs-context')
+    ]);
+  });
+
+  const handleChange = (e: Event | CustomEvent | any) => {
+    console.info(`ids-tabs.on('change') =>`, e.target?.value);
+  };
+</script>
+
+<ids-tabs-context>
+  <ids-tabs color-variant="module" value="contracts">
+    <ids-tab value="app-menu" actionable>
+      <ids-icon icon="menu"></ids-icon>
+      <ids-text type="span" audible>Toggle Application Menu</ids-text>
+    </ids-tab>
+    <ids-tab value="contracts" on:change={handleChange}>Contracts</ids-tab>
+    <ids-tab value="opportunities" on:change={handleChange}>Opportunities</ids-tab>
+    <ids-tab value="attachments" disabled on:change={handleChange}>Attachments</ids-tab>
+    <ids-tab value="notes" on:change={handleChange}>Notes</ids-tab>
+    <ids-tab slot="fixed" value="add" actionable>
+      <ids-icon icon="add"></ids-icon>
+      <ids-text type="span" audible>Add New Tab</ids-text>
+    </ids-tab>
+    <ids-tab slot="fixed" value="reset" actionable>
+      <ids-icon icon="reset"></ids-icon>
+      <ids-text type="span" audible>Remove User-added Tabs</ids-text>
+    </ids-tab>
+    <ids-tab-more overflow></ids-tab-more>
+  </ids-tabs>
+
+  <ids-header>
+    <ids-toolbar>
+      <ids-toolbar-section>
+        <ids-toolbar-section type="title">
+          <ids-text font-size="20" color-variant="alternate" type="h1">Module Tabs</ids-text>
+          <ids-text font-size="14" color-variant="alternate">Top-Level Tabs</ids-text>
+        </ids-toolbar-section>
+      </ids-toolbar-section>
+      <ids-toolbar-section type="buttonset" align="end">
+        {#if $appStore.allowThemeSwitcher}
+          <ids-theme-switcher mode="light" color-variant="alternate"></ids-theme-switcher>
+        {/if}
+      </ids-toolbar-section>
+    </ids-toolbar>
+  </ids-header>
+
+  <div class="ids-tabs-content">
+    <ids-tab-content value="contracts">
+      <ids-layout-grid auto="true">
+        <ids-layout-grid-cell>
+          <ids-text font-size="20" type="h2">Contracts</ids-text>
+          <br />
+          <ids-text font-size="16" type="p">Facilitate cultivate monetize, seize e-services peer-to-peer content
+            integrateAJAX-enabled user-centric strategize. Mindshare; repurpose integrate global addelivery
+            leading-edge frictionless, harness real-time plug-and-play standards-compliant 24/7 enterprise strategize
+            robust infomediaries: functionalities back-end. Killer disintermediate web-enabled ubiquitous empower
+            relationships, solutions, metrics architectures.</ids-text>
+        </ids-layout-grid-cell>
+      </ids-layout-grid>
+    </ids-tab-content>
+    <ids-tab-content value="opportunities">
+      <ids-layout-grid auto="true">
+        <ids-layout-grid-cell>
+          <ids-text font-size="16" type="p">
+            <ids-text font-size="20" type="h2">Opportunities</ids-text>
+            <br />
+            Bricks-and-clicks? Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant
+            global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services
+            leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.
+          </ids-text>
+        </ids-layout-grid-cell>
+      </ids-layout-grid>
+    </ids-tab-content>
+    <ids-tab-content value="attachments">
+      <ids-layout-grid auto="true">
+        <ids-layout-grid-cell>
+          <ids-text font-size="20" type="h2">Attachments</ids-text>
+          <br />
+          <ids-text font-size="16" type="p">
+            Frictionless webservices, killer open-source innovate, best-of-breed, whiteboard interactive back-end
+            optimize capture dynamic front-end. Initiatives ubiquitous 24/7 enhance channels B2B drive frictionless
+            web-readiness generate recontextualize widgets applications. Sexy sticky matrix, user-centred, rich
+            user-centric: peer-to-peer podcasting networking addelivery optimize streamline integrated proactive:
+            granular morph.
+          </ids-text>
+        </ids-layout-grid-cell>
+      </ids-layout-grid>
+    </ids-tab-content>
+    <ids-tab-content value="notes">
+      <ids-layout-grid auto="true">
+        <ids-layout-grid-cell>
+          <ids-text font-size="20" type="h2">Notes</ids-text>
+          <br />
+          <ids-text font-size="16" type="p">
+            Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant
+            global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services
+            leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.
+          </ids-text>
+        </ids-layout-grid-cell>
+      </ids-layout-grid>
+    </ids-tab-content>
+  </div>
+</ids-tabs-context>

--- a/sveltekit-ids-wc/src/routes/ids-tabs/vertical.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-tabs/vertical.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  onMount(async (): Promise<void> => {
+    await Promise.all([
+      import('ids-enterprise-wc/components/ids-tabs/ids-tab'),
+      import('ids-enterprise-wc/components/ids-tabs/ids-tabs')
+    ]);
+  });
+
+  const handleChange = (e: Event | CustomEvent | any) => {
+    console.info(`ids-tabs.on('change') =>`, e.target?.value);
+  };
+</script>
+
+<ids-tabs value="notes" orientation="vertical" id="ids-tabs-vertical">
+  <ids-tab value="contracts" on:change={handleChange}>Contracts</ids-tab>
+  <ids-tab value="opportunities" on:change={handleChange}>Opportunities</ids-tab>
+  <ids-tab value="attachments" disabled on:change={handleChange}>Attachments</ids-tab>
+  <ids-tab value="notes" on:change={handleChange}>Notes</ids-tab>
+</ids-tabs>

--- a/sveltekit-ids-wc/src/routes/ids-tag/dynamic-example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-tag/dynamic-example.svelte
@@ -3,6 +3,7 @@
   import IdsTag from '../../components/ids-tag/IdsTag.svelte';
   import TAG_COLORS from '../../components/ids-tag/colors';
   import { writableTagArray } from './dynamic-example.stores';
+  import { dashCase, prettyFormat } from '../../utils/string';
 
   // Supporting Components
   import IdsCheckbox from '../../components/ids-checkbox/IdsCheckbox.svelte';
@@ -23,10 +24,6 @@
   export let color = TAG_COLORS[0].value;
   export let dismissible = true;
   export let clickable = true;
-
-  const dashCase = (val = '') => {
-    return val.toLowerCase().split(' ').join('-');
-  };
 
   // Adds the contents of the form as a new entry in the writable store.
   // This is automatically updated as new tag in the template below (see $writableTagArray) 
@@ -64,9 +61,6 @@
     writableTagArray.reset();
     refs = [];
   }
-
-  // Allows pretty-looking data formatting in the template
-  const prettyFormat = (str: string) => JSON.stringify( str, null, 2 );
 
   // Listens for the Svelte "Component Event" dispatched by the dynamic `<IdsTag>` svelte component
   const onBeforeTagRemove = (e) => {

--- a/sveltekit-ids-wc/src/routes/ids-tag/dynamic-example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-tag/dynamic-example.svelte
@@ -6,14 +6,17 @@
 
   // Supporting Components
   import IdsCheckbox from '../../components/ids-checkbox/IdsCheckbox.svelte';
+  import IdsDropdown from '../../components/ids-dropdown/IdsDropdown.svelte';
   import IdsInput from '../../components/ids-input/IdsInput.svelte';
+  import IdsListBox from '../../components/ids-list-box/IdsListBox.svelte';
+  import IdsListBoxOption from '../../components/ids-list-box/IdsListBoxOption.svelte';
 
   // `refs/selectedId/currentTag/currentTagStoreRecord` handle the target
   // of the form controls (eitehr a new or existing tag)
   $: refs = [];
   export let selectedId = -1;
   export let currentTag: IdsTag;
-  export let currentTagRecord;
+  export let currentTagRecord: any;
 
   // Form Control Values
   export let text = 'This is a tag';
@@ -112,6 +115,10 @@
     updateStoreValue(e.target, 'dismissible')
   }
 
+  const handleTagColorChange = (e: Event) => {
+    updateStoreValue(e.target, 'color');
+  }
+
   // Makes the "Deselect" button in the template disabled/enabled based on whether or not a tag is selected
   $: hasNoCurrentTag = currentTag === undefined;
 
@@ -178,12 +185,13 @@
       </p>
 
       <p>
-        <label class="ids-text-14" for="style">Normal Dropdown with Dirty Tracker</label>
-        <select id="style" bind:value="{color}" on:change={(e) => updateStoreValue(e.target, 'color')}>
-          {#each TAG_COLORS as option}
-            <option id="color-{dashCase(option.name)}" value={option.value}>{option.name}</option>
-          {/each}
-        </select>
+        <IdsDropdown id="style" bind:value={color} on:change={handleTagColorChange} label="Tag Color">
+          <IdsListBox>
+            {#each TAG_COLORS as option}
+              <IdsListBoxOption id="color-{dashCase(option.name)}" value={option.value}>{option.name}</IdsListBoxOption>
+            {/each}
+          </IdsListBox>
+        </IdsDropdown>
       </p>
 
       <p>

--- a/sveltekit-ids-wc/src/routes/ids-text/example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-text/example.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  onMount(async (): Promise<void> => {
+    await import('ids-enterprise-wc/components/ids-text/ids-text');
+  });
+</script>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="12" type="h1">Texts / Typography</ids-text>
+</ids-layout-grid>
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <ids-text font-size="72">Size 72</ids-text>
+    <ids-text font-size="60">Size 60</ids-text>
+    <ids-text font-size="48">Size 48</ids-text>
+    <ids-text font-size="40">Size 40</ids-text>
+    <ids-text font-size="32">Size 32 (xl)</ids-text>
+    <ids-text font-size="28">Size 28</ids-text>
+    <ids-text font-size="24">Size 24 (lg)</ids-text>
+    <ids-text font-size="20">Size 20</ids-text>
+    <ids-text font-size="16">Size 16 (base)</ids-text>
+    <ids-text font-size="14">Size 14 (sm)</ids-text>
+    <ids-text font-size="12">Size 12 (xs)</ids-text>
+    <ids-text font-size="10">Size 10</ids-text>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-text/index.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-text/index.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import IdsDemoListing from '../../components/demo/IdsDemoListing.svelte';
+
+  const listingData = [
+    {
+      link: 'example',
+      type: 'Main Example',
+      description: 'Simple usage of an IDS Text within Svelte'
+    }
+  ];
+</script>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="20" type="h1">Ids Text Examples</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <IdsDemoListing data={listingData} componentName="ids-text"></IdsDemoListing>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-textarea/example.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-textarea/example.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  onMount(async (): Promise<void> => {
+    await import('ids-enterprise-wc/components/ids-textarea/ids-textarea');
+
+    const btnUpdateValue = document.querySelector('#btn-textarea-update-value');
+    const btnResetValue = document.querySelector('#btn-textarea-reset-value');
+    const textareaUpdateValue: any = document.querySelector('#textarea-update-value') || {};
+    const orgVal = textareaUpdateValue?.value || '';
+    const newVal = 'New value updated';
+
+    // Update value
+    btnUpdateValue?.addEventListener('click', () => {
+      textareaUpdateValue.value = newVal;
+    });
+
+    // Reset value
+    btnResetValue?.addEventListener('click', () => {
+      textareaUpdateValue.value = orgVal;
+    });
+
+    const btnEnable = document.querySelector('#btn-textarea-enable');
+    const btnDisable = document.querySelector('#btn-textarea-disable');
+    const btnReadonly = document.querySelector('#btn-textarea-readonly');
+    const textareaToggleState: any = document.querySelector('#textarea-toggle-state') || {};
+
+    // Enable
+    btnEnable?.addEventListener('click', () => {
+      textareaToggleState.disabled = false;
+      textareaToggleState.readonly = false;
+    });
+
+    // Disable
+    btnDisable?.addEventListener('click', () => {
+      textareaToggleState.disabled = true;
+    });
+
+    // Readonly
+    btnReadonly?.addEventListener('click', () => {
+      textareaToggleState.readonly = true;
+    });
+  });
+</script>
+
+<ids-layout-grid cols="3" gap="md">
+  <ids-layout-grid-cell>
+    <ids-text font-size="12" type="h1">Ids Textarea (Imported into Svelte)</ids-text>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid cols="3" gap="md">
+  <ids-layout-grid-cell>
+    <ids-textarea label="Basic"></ids-textarea>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-textarea label="Disabled" disabled="true">Line One</ids-textarea>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-textarea label="Readonly" readonly="true">Line One</ids-textarea>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-textarea label="Autoselect" autoselect="true">Text select on focus</ids-textarea>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-textarea label="Required" validate="required">I will show an error if you clear the value and tab out.</ids-textarea>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-textarea label="Dirty Tracking" dirty-tracker="true">I will show a dirty indicator if change me and tab out.</ids-textarea>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-textarea label="Resizable" resizable="true" placeholder="Type your notes here..."></ids-textarea>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-textarea label="Toggle State" id="textarea-toggle-state">Line One</ids-textarea>
+    <ids-button id="btn-textarea-enable" type="secondary">
+      <span slot="text">Enable</span>
+    </ids-button>
+    <ids-button id="btn-textarea-disable" type="secondary">
+      <span slot="text">Disable</span>
+    </ids-button>
+    <ids-button id="btn-textarea-readonly" type="secondary">
+      <span slot="text">Readonly</span>
+    </ids-button>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-textarea label="Update Value" id="textarea-update-value">Line One</ids-textarea>
+    <ids-button id="btn-textarea-update-value" type="secondary">
+      <span slot="text">Update Value</span>
+    </ids-button>
+    <ids-button id="btn-textarea-reset-value" type="secondary">
+      <span slot="text">Reset Value</span>
+    </ids-button>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid cols="3" gap="md">
+  <ids-layout-grid-cell>
+    <ids-textarea label="Max Length" maxlength="90">12345</ids-textarea>
+    <ids-textarea label="Max Length (Custom Text)" maxlength="90" char-max-text="This text cannot exceed {0} characters." char-remaining-text="You can type {0} more characters.">Line One</ids-textarea>
+    <ids-textarea label="Auto Grow" autogrow="true" placeholder="Type your notes here..."></ids-textarea>
+    <ids-textarea label="Auto Grow (Max Height)" autogrow="true" autogrow-max-height="200">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</ids-textarea>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-textarea label="Clearable" clearable="true" placeholder="Clearable textarea..."></ids-textarea>
+    <ids-textarea label="Rows" rows="15">Line One</ids-textarea>
+  </ids-layout-grid-cell>
+  <ids-layout-grid-cell>
+    <ids-textarea label="Default align (left)">Default align</ids-textarea>
+    <ids-textarea label="Left align" text-align="start">Left align</ids-textarea>
+    <ids-textarea label="Center align" text-align="center">Center align</ids-textarea>
+    <ids-textarea label="Right align" text-align="end">Right align</ids-textarea>
+  </ids-layout-grid-cell>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <ids-textarea label="Small" size="sm" placeholder="Type your notes here..."></ids-textarea>
+    <ids-textarea label="Medium" size="md" placeholder="Type your notes here..."></ids-textarea>
+    <ids-textarea label="Large" size="lg" placeholder="Type your notes here..."></ids-textarea>
+    <ids-textarea label="Full" size="full" placeholder="Type your notes here..."></ids-textarea>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-textarea/index.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-textarea/index.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import IdsDemoListing from '../../components/demo/IdsDemoListing.svelte';
+
+  const listingData = [
+    {
+      link: 'example',
+      type: 'Main Example',
+      description: 'Simple usage of an IDS TextArea within Svelte'
+    }
+  ];
+</script>
+
+<ids-layout-grid auto="true">
+  <ids-text font-size="20" type="h1">Ids TextArea Examples</ids-text>
+</ids-layout-grid>
+
+<ids-layout-grid auto="true">
+  <ids-layout-grid-cell>
+    <IdsDemoListing data={listingData} componentName="ids-text"></IdsDemoListing>
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/index.svelte
+++ b/sveltekit-ids-wc/src/routes/index.svelte
@@ -52,6 +52,11 @@
       description: 'Displays a Modal Dialog'
     },
     {
+      link: 'ids-popup-menu',
+      component: 'Popup Menu',
+      description: 'Displays a Context Menu'
+    },
+    {
       link: 'ids-tabs',
       component: 'Tabs',
       description: 'Segment different areas'
@@ -64,11 +69,13 @@
   );
 
   // Messages and Alerts
-  /*
   categories[2].components.push(
-    {}
+    {
+      link: 'ids-icon',
+      component: 'Icon',
+      description: 'SVG Icons'
+    }
   );
-  */
 
   // Lists
   categories[3].components.push(
@@ -96,16 +103,22 @@
   // Patterns
   /*
   categories[5].components.push(
-    {}
+    {
+      link: 'ids-locale',
+      component: 'Locale',
+      description: 'Localization'
+    }
   );
   */
 
   // Charts and Visualizations
-  /*
   categories[6].components.push(
-    {}
+    {
+      link: 'ids-color',
+      component: 'Color',
+      description: 'Color Swatches'
+    }
   );
-  */
 
   // Typography
   categories[7].components.push(

--- a/sveltekit-ids-wc/src/routes/index.svelte
+++ b/sveltekit-ids-wc/src/routes/index.svelte
@@ -53,6 +53,22 @@
     }
   );
 
+  // Messages and Alerts
+  /*
+  categories[2].components.push(
+    {}
+  );
+  */
+
+  // Lists
+  categories[3].components.push(
+    {
+      link: 'ids-swaplist',
+      component: 'SwapList',
+      description: 'Displays Swaplist Component'
+    }
+  );
+
   // Layouts
   categories[4].components.push(
     {
@@ -66,6 +82,20 @@
       description: 'Displays a Popup Container'
     }
   );
+
+  // Patterns
+  /*
+  categories[5].components.push(
+    {}
+  );
+  */
+
+  // Charts and Visualizations
+  /*
+  categories[6].components.push(
+    {}
+  );
+  */
 
   // Typography
   categories[7].components.push(

--- a/sveltekit-ids-wc/src/routes/index.svelte
+++ b/sveltekit-ids-wc/src/routes/index.svelte
@@ -31,6 +31,11 @@
       link: 'ids-mask',
       component: 'Mask',
       description: 'Util for masking input'
+    },
+    {
+      link: 'ids-textarea',
+      component: 'Text Area',
+      description: 'An input for multi line text'
     }
   );
   
@@ -45,6 +50,11 @@
       link: 'ids-modal',
       component: 'Modal',
       description: 'Displays a Modal Dialog'
+    },
+    {
+      link: 'ids-tabs',
+      component: 'Tabs',
+      description: 'Segment different areas'
     },
     {
       link: 'ids-tag',

--- a/sveltekit-ids-wc/src/routes/index.svelte
+++ b/sveltekit-ids-wc/src/routes/index.svelte
@@ -58,30 +58,36 @@
   );
 </script>
 
-{#each categories as category}
-	{#if category.components.length}
-		<ids-text type="h1" font-size="24">{category.name}</ids-text>
-		<ids-layout-grid auto="true">
-			<ids-layout-grid-cell>
-				<ids-block-grid align="center">
-					{#each category.components as component}
-						<ids-block-grid-item>
-							<ids-card actionable="true" height="100" href="/{component.link}" target="_self">
-								<div slot="card-content" class="fixed-height">
-									<ids-text
-										type="h2"
-										font-size="16"
-										font-weight="bold"
-										color="slate-100"
-										mode="light"
-										version="new">{component.component}</ids-text>
-									<ids-text type="h2" font-size="16" color="slate-60" mode="light" version="new">{component.description}</ids-text>
-								</div>
-							</ids-card>
-						</ids-block-grid-item>
-					{/each}
-				</ids-block-grid>
-			</ids-layout-grid-cell>
-		</ids-layout-grid>
-	{/if}
-{/each}
+<ids-layout-grid auto="true" gap="md">
+  <ids-layout-grid-cell>
+
+    {#each categories as category}
+      {#if category.components.length}
+        <ids-text type="h1" font-size="24">{category.name}</ids-text>
+        <ids-layout-grid auto="true">
+          <ids-layout-grid-cell>
+            <ids-block-grid align="center">
+              {#each category.components as component}
+                <ids-block-grid-item>
+                  <ids-card actionable="true" height="100" href="/{component.link}" target="_self">
+                    <div slot="card-content" class="fixed-height">
+                      <ids-text
+                        type="h2"
+                        font-size="16"
+                        font-weight="bold"
+                        color="slate-100"
+                        mode="light"
+                        version="new">{component.component}</ids-text>
+                      <ids-text type="h2" font-size="16" color="slate-60" mode="light" version="new">{component.description}</ids-text>
+                    </div>
+                  </ids-card>
+                </ids-block-grid-item>
+              {/each}
+            </ids-block-grid>
+          </ids-layout-grid-cell>
+        </ids-layout-grid>
+      {/if}
+    {/each}
+
+  </ids-layout-grid-cell>
+</ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/index.svelte
+++ b/sveltekit-ids-wc/src/routes/index.svelte
@@ -56,6 +56,15 @@
       description: 'Displays a Popup Container'
     }
   );
+
+  // Typography
+  categories[7].components.push(
+    {
+      link: 'ids-hyperlink',
+      component: 'Hyperlink',
+      description: 'Linked text'
+    }
+  );
 </script>
 
 <ids-layout-grid auto="true" gap="md">

--- a/sveltekit-ids-wc/src/routes/index.svelte
+++ b/sveltekit-ids-wc/src/routes/index.svelte
@@ -42,6 +42,11 @@
       description: 'Simple HTMLButtonElement'
     },
     {
+      link: 'ids-modal',
+      component: 'Modal',
+      description: 'Displays a Modal Dialog'
+    },
+    {
       link: 'ids-tag',
       component: 'Tag',
       description: 'UI Classification'
@@ -68,6 +73,11 @@
       link: 'ids-hyperlink',
       component: 'Hyperlink',
       description: 'Linked text'
+    },
+    {
+      link: 'ids-text',
+      component: 'Text',
+      description: 'An element for plain text'
     }
   );
 </script>

--- a/sveltekit-ids-wc/src/routes/index.svelte
+++ b/sveltekit-ids-wc/src/routes/index.svelte
@@ -26,6 +26,11 @@
       link: 'ids-input',
       component: 'Input',
       description: 'Input element and features'
+    },
+    {
+      link: 'ids-mask',
+      component: 'Mask',
+      description: 'Util for masking input'
     }
   );
   

--- a/sveltekit-ids-wc/src/utils/deepClone.ts
+++ b/sveltekit-ids-wc/src/utils/deepClone.ts
@@ -1,0 +1,86 @@
+/**
+ * NOTE: Keep this file up to date with 
+ * https://github.com/infor-design/enterprise-wc/blob/main/src/utils/ids-deep-clone-utils/ids-deep-clone-utils.ts
+ * until we can import utils directly from this package
+ */
+
+// Store the references to avoid circular reference problems
+const refs: Array<any> = [];
+const refsNew: Array<any> = [];
+
+/**
+ * Deep clone an array creating a new array
+ * @param {any} this The array to clone
+ * @param {Array} arr The array to clone
+ * @param {Function} fn The functional call back used for recursion
+ * @returns {Array} The array's clone
+ */
+export function deepCloneArray(this: any, arr: any, fn?: any) {
+  const keys = Object.keys(arr);
+  const arrClone = new Array(keys.length);
+
+  for (let i = 0; i < keys.length; i += 1) {
+    const k: any = keys[i];
+    const cur = arr[k];
+
+    if (typeof cur !== 'object' || cur === null) {
+      arrClone[k] = cur;
+    } else if (cur instanceof Date) {
+      arrClone[k] = new Date(cur);
+    } else {
+      const index = refs.indexOf(cur);
+      if (index !== -1) {
+        arrClone[k] = refsNew[index];
+      } else {
+        arrClone[k] = fn.call(this, cur);
+      }
+    }
+  }
+  return arrClone;
+}
+
+/**
+ * Deep clone an object creating a new object
+ * @param {object|Array} obj The object or array to clone
+ * @returns {object|Array} The object/array's clone
+ */
+export function deepClone(obj: any) {
+  if (typeof obj !== 'object' || obj === null) {
+    return obj;
+  }
+
+  if (obj instanceof Date) {
+    return new Date(obj);
+  }
+
+  if (Array.isArray(obj)) {
+    return deepCloneArray(obj, deepClone);
+  }
+
+  const objClone: any = {};
+  refs.push(obj);
+  refsNew.push(objClone);
+
+  for (const k in obj) {
+    if (Object.hasOwnProperty.call(obj, k) === false) {
+      continue;
+    }
+
+    const cur = obj[k];
+    if (typeof cur !== 'object' || cur === null) {
+      objClone[k] = cur;
+    } else if (cur instanceof Date) {
+      objClone[k] = new Date(cur);
+    } else {
+      const i = refs.indexOf(cur);
+      if (i !== -1) {
+        objClone[k] = refsNew[i];
+      } else {
+        objClone[k] = deepClone(cur);
+      }
+    }
+  }
+  refs.pop();
+  refsNew.pop();
+  return objClone;
+}

--- a/sveltekit-ids-wc/src/utils/string.ts
+++ b/sveltekit-ids-wc/src/utils/string.ts
@@ -1,0 +1,15 @@
+/**
+ * Converts a string containing a phrase with capital letters and spaces to dash case
+ * @param {string} val incoming string to modify
+ * @returns {string} the modified string
+ */
+export const dashCase = (val = ''): string => {
+  return val.toLowerCase().split(' ').join('-');
+};
+
+/**
+ * Allows pretty-looking data formatting in the template
+ * @param {string} str incoming string to modify
+ * @returns {string} a pretty-looking JSON representation of the string
+ */
+export const prettyFormat = (str: string): string => JSON.stringify(str, null, 2);

--- a/sveltekit-ids-wc/static/data/periods.json
+++ b/sveltekit-ids-wc/static/data/periods.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": 1,
+    "city": "London",
+    "location": "Corporate FY19",
+    "alert": true,
+    "alertClass": "error",
+    "daysLeft": 3,
+    "hoursLeft": 5
+  },
+  {
+    "id": 2,
+    "city": "New York",
+    "location": "Corporate FY19",
+    "alert": true,
+    "alertClass": "alert",
+    "daysLeft": 6,
+    "hoursLeft": 7
+  },
+  {
+    "id": 3,
+    "city": "Vancouver",
+    "location": "Corporate FY19",
+    "alert": false,
+    "alertClass": "",
+    "daysLeft": 8,
+    "hoursLeft": 1
+  },
+  {
+    "id": 4,
+    "city": "Tokyo",
+    "location": "Corporate FY19",
+    "alert": false,
+    "alertClass": "",
+    "daysLeft": 2,
+    "hoursLeft": 1
+  },
+  {
+    "id": 5,
+    "city": "Madrid",
+    "location": "Corporate FY19",
+    "alert": false,
+    "alertClass": "",
+    "daysLeft": 3,
+    "hoursLeft": 1
+  }
+]

--- a/sveltekit-ids-wc/static/data/states.json
+++ b/sveltekit-ids-wc/static/data/states.json
@@ -1,0 +1,238 @@
+[
+  {
+    "id" : "AL",
+    "name" : "Alabama"
+  },
+  {
+    "id" : "AK",
+    "name" : "Alaska"
+  },
+  {
+    "id" : "AS",
+    "name" : "American Samoa"
+  },
+  {
+    "id" : "AZ",
+    "name" : "Arizona"
+  },
+  {
+    "id" : "AR",
+    "name" : "Arkansas"
+  },
+  {
+    "id" : "CA",
+    "name" : "California"
+  },
+  {
+    "id" : "CO",
+    "name" : "Colorado"
+  },
+  {
+    "id" : "CT",
+    "name" : "Connecticut"
+  },
+  {
+    "id" : "DE",
+    "name" : "Delaware"
+  },
+  {
+    "id" : "DC",
+    "name" : "District Of Columbia"
+  },
+  {
+    "id" : "FM",
+    "name" : "Federated States Of Micronesia"
+  },
+  {
+    "id" : "FL",
+    "name" : "Florida"
+  },
+  {
+    "id" : "GA",
+    "name" : "Georgia"
+  },
+  {
+    "id" : "GU",
+    "name" : "Guam"
+  },
+  {
+    "id" : "HI",
+    "name" : "Hawaii"
+  },
+  {
+    "id" : "ID",
+    "name" : "Idaho"
+  },
+  {
+    "id" : "IL",
+    "name" : "Illinois"
+  },
+  {
+    "id" : "IN",
+    "name" : "Indiana"
+  },
+  {
+    "id" : "IA",
+    "name" : "Iowa"
+  },
+  {
+    "id" : "KS",
+    "name" : "Kansas"
+  },
+  {
+    "id" : "KY",
+    "name" : "Kentucky"
+  },
+  {
+    "id" : "LA",
+    "name" : "Louisiana"
+  },
+  {
+    "id" : "ME",
+    "name" : "Maine"
+  },
+  {
+    "id" : "MH",
+    "name" : "Marshall Island Teritory"
+  },
+  {
+    "id" : "MD",
+    "name" : "Maryland"
+  },
+  {
+    "id" : "MA",
+    "name" : "Massachusetts"
+  },
+  {
+    "id" : "MI",
+    "name" : "Michigan"
+  },
+  {
+    "id" : "MN",
+    "name" : "Minnesota"
+  },
+  {
+    "id" : "MS",
+    "name" : "Mississippi"
+  },
+  {
+    "id" : "MO",
+    "name" : "Missouri"
+  },
+  {
+    "id" : "MT",
+    "name" : "Montana"
+  },
+  {
+    "id" : "NE",
+    "name" : "Nebraska"
+  },
+  {
+    "id" : "NV",
+    "name" : "Nevada"
+  },
+  {
+    "id" : "NH",
+    "name" : "New Hampshire"
+  },
+  {
+    "id" : "NJ",
+    "name" : "New Jersey"
+  },
+  {
+    "id" : "NM",
+    "name" : "New Mexico"
+  },
+  {
+    "id" : "NY",
+    "name" : "New York"
+  },
+  {
+    "id" : "NC",
+    "name" : "North Carolina"
+  },
+  {
+    "id" : "ND",
+    "name" : "North Dakota"
+  },
+  {
+    "id" : "MP",
+    "name" : "Northern Mariana Island Teritory"
+  },
+  {
+    "id" : "OH",
+    "name" : "Ohio"
+  },
+  {
+    "id" : "OK",
+    "name" : "Oklahoma"
+  },
+  {
+    "id" : "OR",
+    "name" : "Oregon"
+  },
+  {
+    "id" : "PW",
+    "name" : "Palau"
+  },
+  {
+    "id" : "PA",
+    "name" : "Pennsylvania"
+  },
+  {
+    "id" : "PR",
+    "name" : "Puerto Rico"
+  },
+  {
+    "id" : "RI",
+    "name" : "Rhode Island Teritory"
+  },
+  {
+    "id" : "SC",
+    "name" : "South Carolina"
+  },
+  {
+    "id" : "SD",
+    "name" : "South Dakota"
+  },
+  {
+    "id" : "TN",
+    "name" : "Tennessee"
+  },
+  {
+    "id" : "TX",
+    "name" : "Texas"
+  },
+  {
+    "id" : "UT",
+    "name" : "Utah"
+  },
+  {
+    "id" : "VT",
+    "name" : "Vermont"
+  },
+  {
+    "id" : "VI",
+    "name" : "Virgin Island Teritory"
+  },
+  {
+    "id" : "VA",
+    "name" : "Virginia"
+  },
+  {
+    "id" : "WA",
+    "name" : "Washington"
+  },
+  {
+    "id" : "WV",
+    "name" : "West Virginia"
+  },
+  {
+    "id" : "WI",
+    "name" : "Wisconsin"
+  },
+  {
+    "id" : "WY",
+    "name" : "Wyoming"
+  }
+]


### PR DESCRIPTION
**What does this PR change?**
This PR Adds a number of IDS Component examples used in Sveltekit:

- IdsColor (swatches)
- IdsDropdown
- IdsIcon
- IdsMask
- IdsModal
- IdsPopupMenu
- IdsTabs (standard, vertical, header, module)
- IdsText (Typography)
- IdsTextArea

Some dynamic component examples have been added, but all of the above have at least one direct component usage example.

In addition, some minor improvements were made to the Sveltekit demoapp, including adding some debugging features, data-only routes, and page layout improvements (mostly for mimicking the WebComponents demoapp).

**Related Issues:**
Partially Addresses infor-design/enterprise-wc#792

**To Test:**
Pull this branch, then build/run the Sveltekit demoapp.  Test all available examples at http://localhost:3000