### PR TITLE
Fix broken routing code in Angular samples

### DIFF
--- a/angular-ids-wc/src/app/app-routing.module.ts
+++ b/angular-ids-wc/src/app/app-routing.module.ts
@@ -576,7 +576,8 @@ export const routes: Routes = [
       title: 'IDS Toolbar',
       category: 'Layouts',
       description: 'A container for buttons'
-    },
+    }
+  },
   { 
     path: 'ids-masthead', 
     loadChildren: () => import('./components/ids-masthead/ids-masthead.module').then(m => m.IdsMastheadModule),


### PR DESCRIPTION
Tried running the Angular example project this morning and realized that I didn't correctly resolve a merge conflict when merging some previous PRs, causing the file `src/app/app-routing.module.ts` to be broken.  This PR simply fixes this problem and allows routing to work correctly

**To test:**
Pull/Build/Run, and make sure it's possible to navigate to http://localhost:4200/ids-calendar/example