### PR TITLE
Fix Angular IdsCalendar panel attributes

### DIFF
--- a/angular-ids-wc/src/app/components/ids-calendar/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-calendar/demos/example/example.component.html
@@ -27,7 +27,7 @@
   </ids-layout-grid>
   <ids-layout-grid auto="true">
     <ids-layout-grid-cell auto="true">
-      <ids-calendar #calendar date="10/22/2022" show-legend show-details></ids-calendar>
+      <ids-calendar #calendar date="10/22/2022" [attr.show-legend]="true" [attr.show-details]="true"></ids-calendar>
     </ids-layout-grid-cell>
   </ids-layout-grid>
 </ids-container>


### PR DESCRIPTION
Fixes detail/legend panel attribute binding for angular calendar example.
Fixes https://github.com/infor-design/enterprise-wc/issues/966