### PR TITLE
1046 - Update settings on existing IdsButton examples

### DIFF
--- a/angular-ids-wc/package-lock.json
+++ b/angular-ids-wc/package-lock.json
@@ -16,7 +16,6 @@
         "@angular/platform-browser": "^14.0.4",
         "@angular/platform-browser-dynamic": "^14.0.4",
         "@angular/router": "^14.0.4",
-        "ids-enterprise-wc": "^1.0.0-beta.2",
         "rxjs": "^7.5.5",
         "tslib": "^2.4.0",
         "zone.js": "~0.11.6"
@@ -9340,11 +9339,6 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
-    },
-    "node_modules/ids-enterprise-wc": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/ids-enterprise-wc/-/ids-enterprise-wc-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3JlFNKNwZbLdwarUHSLbFcWmTivqWCP0dpbQqguPUvG+EgSHfnKZNKiqyPxiyEehB3S0H+Ah6aIKOmBCb9cbrg=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -23122,11 +23116,6 @@
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
       "dev": true,
       "requires": {}
-    },
-    "ids-enterprise-wc": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/ids-enterprise-wc/-/ids-enterprise-wc-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3JlFNKNwZbLdwarUHSLbFcWmTivqWCP0dpbQqguPUvG+EgSHfnKZNKiqyPxiyEehB3S0H+Ah6aIKOmBCb9cbrg=="
     },
     "ieee754": {
       "version": "1.2.1",

--- a/angular-ids-wc/package-lock.json
+++ b/angular-ids-wc/package-lock.json
@@ -16,6 +16,7 @@
         "@angular/platform-browser": "^14.0.4",
         "@angular/platform-browser-dynamic": "^14.0.4",
         "@angular/router": "^14.0.4",
+        "ids-enterprise-wc": "^1.0.0-beta.2",
         "rxjs": "^7.5.5",
         "tslib": "^2.4.0",
         "zone.js": "~0.11.6"
@@ -9339,6 +9340,11 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
+    },
+    "node_modules/ids-enterprise-wc": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/ids-enterprise-wc/-/ids-enterprise-wc-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3JlFNKNwZbLdwarUHSLbFcWmTivqWCP0dpbQqguPUvG+EgSHfnKZNKiqyPxiyEehB3S0H+Ah6aIKOmBCb9cbrg=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -23116,6 +23122,11 @@
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
       "dev": true,
       "requires": {}
+    },
+    "ids-enterprise-wc": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/ids-enterprise-wc/-/ids-enterprise-wc-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3JlFNKNwZbLdwarUHSLbFcWmTivqWCP0dpbQqguPUvG+EgSHfnKZNKiqyPxiyEehB3S0H+Ah6aIKOmBCb9cbrg=="
     },
     "ieee754": {
       "version": "1.2.1",

--- a/angular-ids-wc/package.json
+++ b/angular-ids-wc/package.json
@@ -11,6 +11,7 @@
     "@angular/platform-browser": "^14.0.4",
     "@angular/platform-browser-dynamic": "^14.0.4",
     "@angular/router": "^14.0.4",
+    "ids-enterprise-wc": "^1.0.0-beta.2",
     "rxjs": "^7.5.5",
     "tslib": "^2.4.0",
     "zone.js": "~0.11.6"

--- a/angular-ids-wc/package.json
+++ b/angular-ids-wc/package.json
@@ -11,7 +11,6 @@
     "@angular/platform-browser": "^14.0.4",
     "@angular/platform-browser-dynamic": "^14.0.4",
     "@angular/router": "^14.0.4",
-    "ids-enterprise-wc": "^1.0.0-beta.2",
     "rxjs": "^7.5.5",
     "tslib": "^2.4.0",
     "zone.js": "~0.11.6"

--- a/angular-ids-wc/src/app/components/ids-action-sheet/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-action-sheet/demos/example/example.component.html
@@ -15,7 +15,7 @@
         [attr.menu]="'icon-menu'"
         (click)="handleClick($event)"
       >
-        <ids-icon slot="icon" icon="more"></ids-icon>
+        <ids-icon icon="more"></ids-icon>
         <span class="audible">Icon Only Button</span>
       </ids-menu-button>
 

--- a/angular-ids-wc/src/app/components/ids-app-menu/demos/example-footer/example-footer.component.html
+++ b/angular-ids-wc/src/app/components/ids-app-menu/demos/example-footer/example-footer.component.html
@@ -13,7 +13,7 @@
         icon="menu"
         (click)="disableTriggerButton()"
       >
-        <span slot="text" class="audible">Open App Menu</span>
+        <span class="audible">Open App Menu</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>
@@ -38,19 +38,19 @@
     <ids-toolbar slot="header">
       <ids-toolbar-section [attr.align]="'center-even'" [attr.type]="'fluid'">
         <ids-button id="header-btn-download" icon="download" padding="16px">
-          <ids-text slot="text" audible>Download</ids-text>
+          <ids-text audible>Download</ids-text>
         </ids-button>
         <ids-button id="header-btn-print" icon="print">
-          <ids-text slot="text" audible>Print</ids-text>
+          <ids-text audible>Print</ids-text>
         </ids-button>
         <ids-button id="header-btn-purchasing" icon="purchasing">
-          <ids-text slot="text" audible>Purchasing</ids-text>
+          <ids-text audible>Purchasing</ids-text>
         </ids-button>
         <ids-button id="header-btn-notification" icon="notification">
-          <ids-text slot="text" audible>Notification</ids-text>
+          <ids-text audible>Notification</ids-text>
         </ids-button>
         <ids-button id="header-btn-inventory" icon="inventory">
-          <ids-text slot="text" audible>Inventory</ids-text>
+          <ids-text audible>Inventory</ids-text>
         </ids-button>
       </ids-toolbar-section>
     </ids-toolbar>
@@ -153,17 +153,17 @@
     <ids-toolbar slot="footer">
       <ids-toolbar-section [attr.align]="'center-even'" [attr.type]="'fluid'">
         <ids-button id="footer-btn-settings">
-          <ids-icon slot="icon" icon="settings"></ids-icon>
-          <span slot="text">Settings</span>
+          <ids-icon icon="settings"></ids-icon>
+          <span>Settings</span>
         </ids-button>
         <ids-button id="footer-btn-proxy" icon="employee-directory">
-          <ids-text slot="text" audible>Proxy as User</ids-text>
+          <ids-text audible>Proxy as User</ids-text>
         </ids-button>
         <ids-button id="footer-btn-about" icon="info">
-          <ids-text slot="text" audible>About This Application</ids-text>
+          <ids-text audible>About This Application</ids-text>
         </ids-button>
         <ids-button id="footer-btn-logout" icon="logout">
-          <ids-text slot="text" audible>Logout</ids-text>
+          <ids-text audible>Logout</ids-text>
         </ids-button>
       </ids-toolbar-section>
     </ids-toolbar>

--- a/angular-ids-wc/src/app/components/ids-app-menu/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-app-menu/demos/example/example.component.html
@@ -14,7 +14,7 @@
         (click)="disableTriggerButton()"
         [attr.disabled]="disabled"
       >
-        <span slot="text" class="audible">Open App Menu</span>
+        <span class="audible">Open App Menu</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>
@@ -39,19 +39,19 @@
     <ids-toolbar slot="header">
       <ids-toolbar-section [attr.align]="'center-even'" [attr.type]="'fluid'">
         <ids-button id="header-btn-download" icon="download">
-          <ids-text slot="text" audible>Download</ids-text>
+          <ids-text audible>Download</ids-text>
         </ids-button>
         <ids-button id="header-btn-print" icon="print">
-          <ids-text slot="text" audible>Print</ids-text>
+          <ids-text audible>Print</ids-text>
         </ids-button>
         <ids-button id="header-btn-purchasing" icon="purchasing">
-          <ids-text slot="text" audible>Purchasing</ids-text>
+          <ids-text audible>Purchasing</ids-text>
         </ids-button>
         <ids-button id="header-btn-notification" icon="notification">
-          <ids-text slot="text" audible>Notification</ids-text>
+          <ids-text audible>Notification</ids-text>
         </ids-button>
         <ids-button id="header-btn-inventory" icon="inventory">
-          <ids-text slot="text" audible>Inventory</ids-text>
+          <ids-text audible>Inventory</ids-text>
         </ids-button>
       </ids-toolbar-section>
     </ids-toolbar>
@@ -154,17 +154,17 @@
     <ids-toolbar slot="footer">
       <ids-toolbar-section [attr.align]="'center-even'" [attr.type]="'fluid'">
         <ids-button id="footer-btn-settings">
-          <ids-icon slot="icon" icon="settings"></ids-icon>
-          <span slot="text">Settings</span>
+          <ids-icon icon="settings"></ids-icon>
+          <span>Settings</span>
         </ids-button>
         <ids-button id="footer-btn-proxy" icon="employee-directory">
-          <ids-text slot="text" audible>Proxy as User</ids-text>
+          <ids-text audible>Proxy as User</ids-text>
         </ids-button>
         <ids-button id="footer-btn-about" icon="info-linear">
-          <ids-text slot="text" audible>About This Application</ids-text>
+          <ids-text audible>About This Application</ids-text>
         </ids-button>
         <ids-button id="footer-btn-logout" icon="logout">
-          <ids-text slot="text" audible>Logout</ids-text>
+          <ids-text audible>Logout</ids-text>
         </ids-button>
       </ids-toolbar-section>
     </ids-toolbar>

--- a/angular-ids-wc/src/app/components/ids-app-menu/demos/sandbox/sandbox.component.html
+++ b/angular-ids-wc/src/app/components/ids-app-menu/demos/sandbox/sandbox.component.html
@@ -13,7 +13,7 @@
         icon="menu"
         (click)="disableTriggerButton()"
       >
-        <span slot="text" class="audible">Open App Menu</span>
+        <span class="audible">Open App Menu</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-breadcrumb/demos/toolbar/toolbar.component.html
+++ b/angular-ids-wc/src/app/components/ids-breadcrumb/demos/toolbar/toolbar.component.html
@@ -18,8 +18,8 @@
 
       <ids-toolbar-section type="buttonset" align="end">
         <ids-button id="button-6">
-          <span slot="text" class="audible">Trash</span>
-          <ids-icon slot="icon" icon="delete"></ids-icon>
+          <span class="audible">Trash</span>
+          <ids-icon icon="delete"></ids-icon>
         </ids-button>
       </ids-toolbar-section>
     </ids-toolbar>

--- a/angular-ids-wc/src/app/components/ids-button/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-button/demos/example/example.component.html
@@ -7,25 +7,25 @@
   <ids-layout-grid cols="4" gap="md">
     <ids-layout-grid-cell>
       <ids-button id="test-button-default">
-        <span slot="text">Default Button</span>
+        <span>Default Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-button-primary" type="primary">
-        <span slot="text">Primary Button</span>
+        <span>Primary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-button-secondary" type="secondary">
-        <span slot="text">Secondary Button</span>
+        <span>Secondary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-button-tertiary" type="tertiary">
-        <span slot="text">Tertiary Button</span>
+        <span>Tertiary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>
@@ -35,25 +35,25 @@
   <ids-layout-grid cols="4" gap="md">
     <ids-layout-grid-cell>
       <ids-button id="test-disabled-button-default" disabled="true">
-        <span slot="text">Default Button</span>
+        <span>Default Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-disabled-button-primary" type="primary"  disabled="true">
-        <span slot="text">Primary Button</span>
+        <span>Primary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-disabled-button-secondary" type="secondary"  disabled="true">
-        <span slot="text">Secondary Button</span>
+        <span>Secondary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-disabled-button-tertiary" type="tertiary"  disabled="true">
-        <span slot="text">Tertiary Button</span>
+        <span>Tertiary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>
@@ -64,28 +64,28 @@
     <ids-layout-grid-cell>
       <ids-button id="test-icon-only-button-default">
         <span class="audible">Default Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-only-button-primary" type="primary">
         <span class="audible">Primary Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-only-button-secondary" type="secondary">
         <span class="audible">Secondary Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-only-button-tertiary" type="tertiary">
         <span class="audible">Tertiary Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>
@@ -96,29 +96,29 @@
   <ids-layout-grid cols="4" gap="md">
     <ids-layout-grid-cell>
       <ids-button id="test-icon-button-default">
-        <ids-icon slot="icon" icon="settings"></ids-icon>
-        <span slot="text">Default Button</span>
+        <ids-icon icon="settings"></ids-icon>
+        <span>Default Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-button-primary" type="primary">
-        <ids-icon slot="icon" icon="settings"></ids-icon>
-        <span slot="text">Primary Button</span>
+        <ids-icon icon="settings"></ids-icon>
+        <span>Primary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-button-secondary" type="secondary">
-        <ids-icon slot="icon" icon="settings"></ids-icon>
-        <span slot="text">Secondary Button</span>
+        <ids-icon icon="settings"></ids-icon>
+        <span>Secondary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-button-tertiary" type="tertiary">
-        <ids-icon slot="icon" icon="settings"></ids-icon>
-        <span slot="text">Tertiary Button</span>
+        <ids-icon icon="settings"></ids-icon>
+        <span>Tertiary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>
@@ -128,29 +128,29 @@
   <ids-layout-grid cols="4" gap="md">
     <ids-layout-grid-cell>
       <ids-button id="test-icon-end-button-default" icon-align="end">
-        <span slot="text">Default Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <span>Default Button</span>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-end-button-primary" icon-align="end" type="primary">
-        <span slot="text">Primary Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <span>Primary Button</span>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-end-button-secondary" icon-align="end" type="secondary">
-        <span slot="text">Secondary Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <span>Secondary Button</span>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-end-button-tertiary" icon-align="end" type="tertiary">
-        <span slot="text">Tertiary Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <span>Tertiary Button</span>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-button/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-button/demos/example/example.component.html
@@ -62,30 +62,26 @@
   </ids-layout-grid>
   <ids-layout-grid cols="4" gap="md">
     <ids-layout-grid-cell>
-      <ids-button id="test-icon-only-button-default">
+      <ids-button id="test-icon-only-button-default" icon="settings">
         <span class="audible">Default Button</span>
-        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
-      <ids-button id="test-icon-only-button-primary" type="primary">
+      <ids-button id="test-icon-only-button-primary" type="primary" icon="settings">
         <span class="audible">Primary Button</span>
-        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
-      <ids-button id="test-icon-only-button-secondary" type="secondary">
+      <ids-button id="test-icon-only-button-secondary" type="secondary" icon="settings">
         <span class="audible">Secondary Button</span>
-        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
-      <ids-button id="test-icon-only-button-tertiary" type="tertiary">
+      <ids-button id="test-icon-only-button-tertiary" type="tertiary" icon="settings">
         <span class="audible">Tertiary Button</span>
-        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-button/demos/responsive/responsive.component.html
+++ b/angular-ids-wc/src/app/components/ids-button/demos/responsive/responsive.component.html
@@ -9,13 +9,13 @@
   <ids-layout-grid>
     <ids-layout-grid-cell col-span="12">
       <ids-button type="secondary" width="100%">
-        <span slot="text">100%</span>
+        <span>100%</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell col-span="12">
       <ids-button type="secondary" width="50%">
-        <span slot="text">50%</span>
+        <span>50%</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>
@@ -28,15 +28,15 @@
   <ids-layout-grid>
     <ids-layout-grid-cell col-span="12">
       <ids-button type="secondary" width="500px">
-        <ids-icon slot="icon" icon="settings"></ids-icon>
-        <span slot="text">500px</span>
+        <ids-icon icon="settings"></ids-icon>
+        <span>500px</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell col-span="12">
       <ids-button type="secondary" width="250px">
-        <ids-icon slot="icon" icon="settings"></ids-icon>
-        <span slot="text">250px</span>
+        <ids-icon icon="settings"></ids-icon>
+        <span>250px</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-button/demos/variant-alternate/variant-alternate.component.html
+++ b/angular-ids-wc/src/app/components/ids-button/demos/variant-alternate/variant-alternate.component.html
@@ -8,25 +8,25 @@
   <ids-layout-grid cols="4" gap="md">
     <ids-layout-grid-cell>
       <ids-button id="test-button-default" color-variant="alternate">
-        <span slot="text">Default Button</span>
+        <span>Default Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-button-primary" type="primary" color-variant="alternate">
-        <span slot="text">Primary Button</span>
+        <span>Primary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-button-secondary" type="secondary" color-variant="alternate">
-        <span slot="text">Secondary Button</span>
+        <span>Secondary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-button-tertiary" type="tertiary" color-variant="alternate">
-        <span slot="text">Tertiary Button</span>
+        <span>Tertiary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>
@@ -38,25 +38,25 @@
   <ids-layout-grid cols="4" gap="md">
     <ids-layout-grid-cell>
       <ids-button id="test-disabled-button-default" disabled="true" color-variant="alternate">
-        <span slot="text">Default Button</span>
+        <span>Default Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-disabled-button-primary" type="primary" disabled="true" color-variant="alternate">
-        <span slot="text">Primary Button</span>
+        <span>Primary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-disabled-button-secondary" type="secondary" disabled="true" color-variant="alternate">
-        <span slot="text">Secondary Button</span>
+        <span>Secondary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-disabled-button-tertiary" type="tertiary" disabled="true" color-variant="alternate">
-        <span slot="text">Tertiary Button</span>
+        <span>Tertiary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>
@@ -69,28 +69,28 @@
     <ids-layout-grid-cell>
       <ids-button id="test-icon-only-button-default" color-variant="alternate">
         <span class="audible">Default Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-only-button-primary" type="primary" color-variant="alternate">
         <span class="audible">Primary Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-only-button-secondary" type="secondary" color-variant="alternate">
         <span class="audible">Secondary Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-only-button-tertiary" type="tertiary" color-variant="alternate">
         <span class="audible">Tertiary Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>
@@ -102,29 +102,29 @@
   <ids-layout-grid cols="4" gap="md">
     <ids-layout-grid-cell>
       <ids-button id="test-icon-button-default" color-variant="alternate">
-        <ids-icon slot="icon" icon="settings"></ids-icon>
-        <span slot="text">Default Button</span>
+        <ids-icon icon="settings"></ids-icon>
+        <span>Default Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-button-primary" type="primary" color-variant="alternate">
-        <ids-icon slot="icon" icon="settings"></ids-icon>
-        <span slot="text">Primary Button</span>
+        <ids-icon icon="settings"></ids-icon>
+        <span>Primary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-button-secondary" type="secondary" color-variant="alternate">
-        <ids-icon slot="icon" icon="settings"></ids-icon>
-        <span slot="text">Secondary Button</span>
+        <ids-icon icon="settings"></ids-icon>
+        <span>Secondary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-button-tertiary" type="tertiary" color-variant="alternate">
-        <ids-icon slot="icon" icon="settings"></ids-icon>
-        <span slot="text">Tertiary Button</span>
+        <ids-icon icon="settings"></ids-icon>
+        <span>Tertiary Button</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>
@@ -136,29 +136,29 @@
   <ids-layout-grid cols="4" gap="md">
     <ids-layout-grid-cell>
       <ids-button id="test-icon-end-button-default" icon-align="end" color-variant="alternate">
-        <span slot="text">Default Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <span>Default Button</span>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-end-button-primary" icon-align="end" type="primary" color-variant="alternate">
-        <span slot="text">Primary Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <span>Primary Button</span>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-end-button-secondary" icon-align="end" type="secondary" color-variant="alternate">
-        <span slot="text">Secondary Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <span>Secondary Button</span>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-button id="test-icon-end-button-tertiary" icon-align="end" type="tertiary" color-variant="alternate">
-        <span slot="text">Tertiary Button</span>
-        <ids-icon slot="icon" icon="settings"></ids-icon>
+        <span>Tertiary Button</span>
+        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-button/demos/variant-alternate/variant-alternate.component.html
+++ b/angular-ids-wc/src/app/components/ids-button/demos/variant-alternate/variant-alternate.component.html
@@ -67,30 +67,26 @@
 
   <ids-layout-grid cols="4" gap="md">
     <ids-layout-grid-cell>
-      <ids-button id="test-icon-only-button-default" color-variant="alternate">
+      <ids-button id="test-icon-only-button-default" icon="settings" color-variant="alternate">
         <span class="audible">Default Button</span>
-        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
-      <ids-button id="test-icon-only-button-primary" type="primary" color-variant="alternate">
+      <ids-button id="test-icon-only-button-primary" icon="settings" type="primary" color-variant="alternate">
         <span class="audible">Primary Button</span>
-        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
-      <ids-button id="test-icon-only-button-secondary" type="secondary" color-variant="alternate">
+      <ids-button id="test-icon-only-button-secondary" icon="settings" type="secondary" color-variant="alternate">
         <span class="audible">Secondary Button</span>
-        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
-      <ids-button id="test-icon-only-button-tertiary" type="tertiary" color-variant="alternate">
+      <ids-button id="test-icon-only-button-tertiary" icon="settings" type="tertiary" color-variant="alternate">
         <span class="audible">Tertiary Button</span>
-        <ids-icon icon="settings"></ids-icon>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-calendar/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-calendar/demos/example/example.component.html
@@ -2,7 +2,7 @@
   <ids-toolbar>
     <ids-toolbar-section [attr.align]="'end'" [type]="'fluid'">
       <ids-menu-button [menu]="'add-event'" value="${view}">
-        <ids-icon slot="icon" icon="add"></ids-icon>
+        <ids-icon icon="add"></ids-icon>
         <span class="audible">Add Event</span>
       </ids-menu-button>
       <ids-popup-menu #addMenu id="add-event" trigger="click">

--- a/angular-ids-wc/src/app/components/ids-card/demos/footer/footer.component.html
+++ b/angular-ids-wc/src/app/components/ids-card/demos/footer/footer.component.html
@@ -16,7 +16,7 @@
           </div>
           <div slot="card-footer">
             <ids-button>
-              <span slot="text">Load more</span>
+              <span>Load more</span>
             </ids-button>
           </div>
         </ids-card>

--- a/angular-ids-wc/src/app/components/ids-card/demos/info/info.component.html
+++ b/angular-ids-wc/src/app/components/ids-card/demos/info/info.component.html
@@ -16,7 +16,7 @@
 
           <ids-card-action>
             <ids-menu-button menu="icon-menu">
-              <ids-icon slot="icon" icon="more" [vertical]="true"></ids-icon>
+              <ids-icon icon="more" [vertical]="true"></ids-icon>
               <span class="audible">Icon More Button</span>
             </ids-menu-button>
           </ids-card-action>
@@ -34,7 +34,7 @@
 
           <ids-card-action>
             <ids-menu-button menu="icon-menu">
-              <ids-icon slot="icon" icon="more" [vertical]="'true'"></ids-icon>
+              <ids-icon icon="more" [vertical]="'true'"></ids-icon>
               <span class="audible">Icon More Button</span>
             </ids-menu-button>
           </ids-card-action>
@@ -52,7 +52,7 @@
 
           <ids-card-action>
             <ids-menu-button menu="icon-menu">
-              <ids-icon slot="icon" icon="more" [vertical]="true"></ids-icon>
+              <ids-icon icon="more" [vertical]="true"></ids-icon>
               <span class="audible">Icon More Button</span>
             </ids-menu-button>
           </ids-card-action>

--- a/angular-ids-wc/src/app/components/ids-card/demos/toolbar/toolbar.component.html
+++ b/angular-ids-wc/src/app/components/ids-card/demos/toolbar/toolbar.component.html
@@ -13,7 +13,7 @@
             </ids-toolbar-section>
             <ids-toolbar-section type="buttonset" align="end">
               <ids-menu-button id="icon-btn-more" menu="icon-more">
-                <ids-icon slot="icon" icon="more"></ids-icon>
+                <ids-icon icon="more"></ids-icon>
                 <span class="audible">Icon More Button</span>
               </ids-menu-button>
             </ids-toolbar-section>
@@ -26,7 +26,7 @@
             </ids-toolbar-section>
             <ids-toolbar-section type="buttonset" align="end">
               <ids-menu-button id="icon-btn-filter" menu="icon-filter">
-                <ids-icon slot="icon" icon="filter"></ids-icon>
+                <ids-icon icon="filter"></ids-icon>
                 <span class="audible">Icon Filter Button</span>
               </ids-menu-button>
             </ids-toolbar-section>

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/example/example.component.html
@@ -32,10 +32,10 @@
       <ids-text font-size="12" type="h1">Ids Indeterminate</ids-text><br />
       <ids-checkbox label="Indeterminate" indeterminate="true" id="cb-indeterminate"></ids-checkbox>
       <ids-button type="secondary" id="btn-set-indeterminate">
-        <span slot="text">Set</span>
+        <span>Set</span>
       </ids-button>
       <ids-button type="secondary" id="btn-remove-indeterminate">
-        <span slot="text">Remove</span>
+        <span>Remove</span>
       </ids-button>
 
       <br /><br />

--- a/angular-ids-wc/src/app/components/ids-empty-message/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-empty-message/demos/example/example.component.html
@@ -17,7 +17,7 @@
             <ids-text type="h2" font-size="20" label="true" slot="label">Document Management</ids-text>
             <ids-text label="true" slot="description">Description of empty message that explains why and possible contain a hyperlink.</ids-text>
             <ids-button class="action-button" slot="button" type="primary">
-              <span slot="text">Action</span>
+              <span>Action</span>
             </ids-button>
           </ids-empty-message>
         </div>

--- a/angular-ids-wc/src/app/components/ids-expandable-area/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-expandable-area/demos/example/example.component.html
@@ -70,8 +70,8 @@
 
       <ids-expandable-area type="toggle-btn">
         <ids-toggle-button (click)="handleToggleButton($event)" hitbox="true" slot="header" id="test-expandable-toggle-button" [attr.icon-on]="'caret-up'" [attr.icon-off]="'caret-down'" [attr.text-off]="'Employee'" [attr.text-on]="'Employee'" icon-align="end" no-padding="true">
-          <ids-icon slot="icon" icon="caret-up" size="small"></ids-icon>
-          <span slot="text">Employee</span>
+          <ids-icon icon="caret-up" size="small"></ids-icon>
+          <span>Employee</span>
         </ids-toggle-button>
         <ids-text slot="pane">
           Ubiquitous out-of-the-box, scalable; communities disintermediate beta-test, enable utilize markets dynamic

--- a/angular-ids-wc/src/app/components/ids-lookup/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-lookup/demos/example/example.component.html
@@ -26,7 +26,7 @@
         <ids-modal slot="lookup-modal" id="custom-lookup-modal" aria-labelledby="custom-lookup-modal-title">
           <ids-text slot="title" font-size="24" type="h2" id="lookup-modal-title">Custom Lookup Modal</ids-text>
           <ids-modal-button slot="buttons" id="modal-cancel-btn" type="primary">
-            <span slot="text">Apply</span>
+            <span>Apply</span>
           </ids-modal-button>
         </ids-modal>
       </ids-lookup>

--- a/angular-ids-wc/src/app/components/ids-masthead/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-masthead/demos/example/example.component.html
@@ -13,17 +13,17 @@
     <ids-layout-grid-cell>
       <ids-masthead title="Infor Application" icon="logo" role="navigation">
         <section title="start" slot="start">
-          <ids-button icon="grid"><span slot="text" class="audible">Grid Button</span></ids-button>
+          <ids-button icon="grid"><span class="audible">Grid Button</span></ids-button>
         </section>
         <section title="center" slot="center">
-          <ids-button icon="home"><span slot="text">Home</span></ids-button>
-          <ids-button icon="star-outlined"><span slot="text">Star</span></ids-button>
-          <ids-button icon="info"><span slot="text">Info</span></ids-button>
+          <ids-button icon="home"><span>Home</span></ids-button>
+          <ids-button icon="star-outlined"><span>Star</span></ids-button>
+          <ids-button icon="info"><span>Info</span></ids-button>
         </section>
         <section title="end" slot="end">
-          <ids-button icon="user"><span slot="text" class="audible">User Button</span></ids-button>
-          <ids-button icon="mingle-share"><span slot="text" class="audible">Mingle Button</span></ids-button>
-          <ids-button icon="bookmark-outlined"><span slot="text" class="audible">Bookmark Button</span></ids-button>
+          <ids-button icon="user"><span class="audible">User Button</span></ids-button>
+          <ids-button icon="mingle-share"><span class="audible">Mingle Button</span></ids-button>
+          <ids-button icon="bookmark-outlined"><span class="audible">Bookmark Button</span></ids-button>
         </section>
       </ids-masthead>
     </ids-layout-grid-cell>

--- a/angular-ids-wc/src/app/components/ids-menu-button/demos/disabled/disabled.component.html
+++ b/angular-ids-wc/src/app/components/ids-menu-button/demos/disabled/disabled.component.html
@@ -33,7 +33,7 @@
         [attr.menu]="'my-menu'" 
         [attr.disabled]="disabled"
       >
-        <span slot="text">Settings</span>
+        <span>Settings</span>
       </ids-menu-button>
       <ids-popup-menu 
         id="my-menu" 

--- a/angular-ids-wc/src/app/components/ids-menu-button/demos/display-selected/display-selected.component.html
+++ b/angular-ids-wc/src/app/components/ids-menu-button/demos/display-selected/display-selected.component.html
@@ -15,7 +15,7 @@
         dropdown-icon
         [attr.menu]="'my-menu'"
       >
-        <span #btnSpanEl slot="text">Choose a Program Type...</span>
+        <span #btnSpanEl>Choose a Program Type...</span>
       </ids-menu-button>
       <ids-popup-menu 
         id="my-menu" 

--- a/angular-ids-wc/src/app/components/ids-menu-button/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-menu-button/demos/example/example.component.html
@@ -15,7 +15,7 @@
         [type]="'tertiary'" 
         [menu]="'my-menu'"
       >
-        <span slot="text">Settings</span>
+        <span>Settings</span>
       </ids-menu-button>
       <ids-popup-menu
         id="my-menu" 
@@ -45,7 +45,7 @@
         id="icon-button" 
         [attr.menu]="'icon-menu'"
       >
-        <ids-icon slot="icon" icon="more"></ids-icon>
+        <ids-icon icon="more"></ids-icon>
         <span class="audible">Icon Only Button</span>
       </ids-menu-button>
       <ids-popup-menu

--- a/angular-ids-wc/src/app/components/ids-menu-button/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-menu-button/demos/example/example.component.html
@@ -42,10 +42,10 @@
       </ids-popup-menu>
 
       <ids-menu-button 
+        icon="more"
         id="icon-button" 
         [attr.menu]="'icon-menu'"
       >
-        <ids-icon icon="more"></ids-icon>
         <span class="audible">Icon Only Button</span>
       </ids-menu-button>
       <ids-popup-menu

--- a/angular-ids-wc/src/app/components/ids-modal/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/example/example.component.html
@@ -4,7 +4,7 @@
   <ids-modal #modal id="my-modal" aria-labelledby="my-modal-title">
     <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
     <ids-modal-button slot="buttons" id="modal-close-btn" type="primary">
-      <span slot="text">OK</span>
+      <span>OK</span>
     </ids-modal-button>
     <ids-text align="left">This is an active IDS Modal component</ids-text>
   </ids-modal>
@@ -15,7 +15,7 @@
   <ids-layout-grid auto="true">
     <ids-layout-grid-cell>
       <ids-button (click)="handleShow()" id="modal-trigger-btn" type="secondary">
-        <span slot="text">Trigger a Modal</span>
+        <span>Trigger a Modal</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-modal/demos/focus/focus.component.html
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/focus/focus.component.html
@@ -10,10 +10,10 @@
     <ids-checkbox id="setting-cycle" label="Cycle Focus" checked></ids-checkbox>
 
     <ids-modal-button slot="buttons" id="modal-cancel-btn" type="secondary" cancel>
-      <span slot="text">Cancel</span>
+      <span>Cancel</span>
     </ids-modal-button>
     <ids-modal-button slot="buttons" id="modal-save-btn" type="primary">
-      <span slot="text">Save</span>
+      <span>Save</span>
     </ids-modal-button>
   </ids-modal>
 
@@ -23,7 +23,7 @@
   <ids-layout-grid auto="true">
     <ids-layout-grid-cell>
       <ids-button id="modal-trigger-btn" type="secondary">
-        <span slot="text">Observe Focus Capture Behavior</span>
+        <span>Observe Focus Capture Behavior</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-modal/demos/fullsize/fullsize.component.html
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/fullsize/fullsize.component.html
@@ -4,7 +4,7 @@
   <ids-modal id="my-modal" aria-labelledby="my-modal-title">
     <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
     <ids-modal-button slot="buttons" id="modal-close-btn" type="primary">
-      <span slot="text">OK</span>
+      <span>OK</span>
     </ids-modal-button>
     <ids-text>This modal will appear fullsize when the browser viewport is below the <span id="break">"sm (600px)"</span> breakpoint.<br /><br />
       <ids-text font-size="16">Current Window Width:</ids-text>
@@ -29,7 +29,7 @@
   <ids-layout-grid auto="true">
     <ids-layout-grid-cell>
       <ids-button id="modal-trigger-btn" type="secondary">
-        <span slot="text">Trigger a Modal</span>
+        <span>Trigger a Modal</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-modal/demos/keep-open/keep-open.component.html
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/keep-open/keep-open.component.html
@@ -4,7 +4,7 @@
   <ids-modal id="my-modal" aria-labelledby="my-modal-title">
     <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
     <ids-modal-button slot="buttons" id="modal-close-btn" type="primary">
-      <span slot="text">OK</span>
+      <span>OK</span>
     </ids-modal-button>
     <ids-text>The checkbox below controls whether or not a user can click in the overlay to close this Modal</ids-text>
     <br>
@@ -17,7 +17,7 @@
   <ids-layout-grid auto="true">
     <ids-layout-grid-cell>
       <ids-button id="modal-trigger-btn" type="secondary">
-        <span slot="text">Trigger a Modal</span>
+        <span>Trigger a Modal</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-modal/demos/nested/nested.component.html
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/nested/nested.component.html
@@ -5,10 +5,10 @@
     <ids-text slot="title" font-size="24" type="h2" id="parent-modal-title">Parent Modal</ids-text>
     <ids-text>This is the Parent IDS Modal</ids-text><br>
     <ids-modal-button slot="buttons" id="parent-modal-close-btn" type="secondary" cancel>
-      <span slot="text">Close</span>
+      <span>Close</span>
     </ids-modal-button>
     <ids-modal-button slot="buttons" id="nested-modal-trigger-btn" type="primary">
-      <span slot="text">Open Another</span>
+      <span>Open Another</span>
     </ids-modal-button>
   </ids-modal>
 
@@ -16,7 +16,7 @@
     <ids-text slot="title" font-size="24" type="h2" id="nested-modal-title">Nested Modal</ids-text>
     <ids-text>This is the Nested IDS Modal</ids-text><br>
     <ids-modal-button slot="buttons" id="nested-modal-close-btn" type="secondary" cancel>
-      <span slot="text">Close</span>
+      <span>Close</span>
     </ids-modal-button>
   </ids-modal>
 
@@ -26,7 +26,7 @@
   <ids-layout-grid auto="true">
     <ids-layout-grid-cell>
       <ids-button id="parent-modal-trigger-btn" type="secondary">
-        <span slot="text">Trigger a Modal</span>
+        <span>Trigger a Modal</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-modal/demos/visible/visible.component.html
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/visible/visible.component.html
@@ -5,7 +5,7 @@
     <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
     <ids-text>This is an active IDS Modal component</ids-text>
     <ids-modal-button slot="buttons" id="modal-close-btn" type="secondary" cancel>
-      <span slot="text">OK</span>
+      <span>OK</span>
     </ids-modal-button>
   </ids-modal>
 
@@ -18,7 +18,7 @@
   <ids-layout-grid auto="true">
     <ids-layout-grid-cell>
       <ids-button id="modal-trigger-btn" type="secondary">
-        <span slot="text">Trigger a Modal</span>
+        <span>Trigger a Modal</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-popup/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-popup/demos/example/example.component.html
@@ -11,7 +11,7 @@
         id="popup-trigger-btn"
         type="secondary"
       >
-        <span slot="text">Trigger a Popup</span>
+        <span>Trigger a Popup</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-progress-bar/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-progress-bar/demos/example/example.component.html
@@ -13,15 +13,15 @@
       <ids-progress-bar id="elem-progress" label="Percent complete" value="10"></ids-progress-bar>
 
       <ids-toggle-button id="btn-progress-value" icon-off="rocket" icon-on="rocket" text-off="Update Value" text-on="Reset Value">
-        <span slot="text"></span>
+        <span></span>
       </ids-toggle-button>
 
       <ids-toggle-button id="btn-progress-disable" icon-off="unlink" icon-on="unlink" text-off="Disable" text-on="Enable">
-        <span slot="text"></span>
+        <span></span>
       </ids-toggle-button>
 
       <ids-toggle-button id="btn-progress-set-label" icon-off="settings" icon-on="settings" text-off="Audible label" text-on="Inaudible label">
-        <span slot="text"></span>
+        <span></span>
       </ids-toggle-button>
 
     </ids-layout-grid-cell>

--- a/angular-ids-wc/src/app/components/ids-radio/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/example/example.component.html
@@ -54,10 +54,10 @@
         <ids-radio value="opt3" label="Option three" disabled="true"></ids-radio>
       </ids-radio-group>
       <ids-button type="secondary" id="btn-radio-clear">
-        <span slot="text">Clear</span>
+        <span>Clear</span>
       </ids-button>
       <ids-button type="secondary" id="btn-radio-validate">
-        <span slot="text">Validate</span>
+        <span>Validate</span>
       </ids-button>
 
       <br/><br/>

--- a/angular-ids-wc/src/app/components/ids-search-field/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-search-field/demos/example/example.component.html
@@ -42,7 +42,7 @@
         <ids-toolbar>
           <ids-toolbar-section>
             <ids-button icon="menu" role="button">
-              <span slot="text" class="audible">Application Menu Trigger</span>
+              <span class="audible">Application Menu Trigger</span>
             </ids-button>
           </ids-toolbar-section>
           <ids-toolbar-section type="title">

--- a/angular-ids-wc/src/app/components/ids-textarea/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-textarea/demos/example/example.component.html
@@ -32,22 +32,22 @@
     <ids-layout-grid-cell>
       <ids-textarea label="Toggle State" id="textarea-toggle-state">Line One</ids-textarea>
       <ids-button id="btn-textarea-enable" type="secondary">
-        <span slot="text">Enable</span>
+        <span>Enable</span>
       </ids-button>
       <ids-button id="btn-textarea-disable" type="secondary">
-        <span slot="text">Disable</span>
+        <span>Disable</span>
       </ids-button>
       <ids-button id="btn-textarea-readonly" type="secondary">
-        <span slot="text">Readonly</span>
+        <span>Readonly</span>
       </ids-button>
     </ids-layout-grid-cell>
     <ids-layout-grid-cell>
       <ids-textarea label="Update Value" id="textarea-update-value">Line One</ids-textarea>
       <ids-button id="btn-textarea-update-value" type="secondary">
-        <span slot="text">Update Value</span>
+        <span>Update Value</span>
       </ids-button>
       <ids-button id="btn-textarea-reset-value" type="secondary">
-        <span slot="text">Reset Value</span>
+        <span>Reset Value</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-toast/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-toast/demos/example/example.component.html
@@ -8,7 +8,7 @@
   <ids-layout-grid auto="true">
     <ids-layout-grid-cell>
       <ids-button id="btn-toast-demo" type="secondary">
-        <span slot="text">Toast Message</span>
+        <span>Toast Message</span>
       </ids-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-toast/demos/sandbox/sandbox.component.html
+++ b/angular-ids-wc/src/app/components/ids-toast/demos/sandbox/sandbox.component.html
@@ -10,7 +10,7 @@
   <ids-layout-grid auto="true">
     <ids-layout-grid-cell>
       <ids-button id="btn-toast-variant" type="secondary">
-        <span slot="text">Show Toast (choose settings below)</span>
+        <span>Show Toast (choose settings below)</span>
       </ids-button>
       <br /><br />
 
@@ -79,21 +79,21 @@
   <ids-layout-grid auto="true">
     <ids-layout-grid-cell>
       <ids-button id="btn-toast-save-position-1" type="secondary">
-        <span slot="text">Show Toast(1)</span>
+        <span>Show Toast(1)</span>
       </ids-button>
       <ids-button id="btn-toast-clear-position-1" type="secondary">
-        <span slot="text">Clear position for saved Toast(1)</span>
+        <span>Clear position for saved Toast(1)</span>
       </ids-button>
       <br/><br/>
       <ids-button id="btn-toast-save-position-2" type="secondary">
-        <span slot="text">Show Toast(2)</span>
+        <span>Show Toast(2)</span>
       </ids-button>
       <ids-button id="btn-toast-clear-position-2" type="secondary">
-        <span slot="text">Clear position for saved Toast(2)</span>
+        <span>Clear position for saved Toast(2)</span>
       </ids-button>
       <br /><br />
       <ids-button id="btn-toast-clear-position-all" type="secondary">
-        <span slot="text">Clear all</span>
+        <span>Clear all</span>
       </ids-button>
       <ids-text class="inline">Clear all toast related saved position from local storage</ids-text>
     </ids-layout-grid-cell>
@@ -107,8 +107,8 @@
   <ids-layout-grid auto="true">
     <ids-layout-grid-cell>
       <ids-button id="btn-toast-markup" type="secondary">
-        <span slot="text">Toast - By markup</span>
-        <span slot="text"></span>
+        <span>Toast - By markup</span>
+        <span></span>
       </ids-button>
       <ids-text class="inline">Toast message setup by markup</ids-text>
       <ids-toast id="toast-markup" destroy-on-complete="false">

--- a/angular-ids-wc/src/app/components/ids-toggle-button/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-toggle-button/demos/example/example.component.html
@@ -14,8 +14,8 @@
         [attr.text-on]="'Toggle Button (On)'"
         (click)="handleToggle($event)"
       >
-        <ids-icon slot="icon" icon="settings"></ids-icon>
-        <span slot="text"></span>
+        <ids-icon icon="settings"></ids-icon>
+        <span></span>
       </ids-toggle-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-toggle-button/demos/icon-align-right/icon-align-right.component.html
+++ b/angular-ids-wc/src/app/components/ids-toggle-button/demos/icon-align-right/icon-align-right.component.html
@@ -15,8 +15,8 @@
         [attr.text-on]="'Favorite (On)'"
         (click)="handleToggle($event)"
       >
-        <ids-icon slot="icon" icon="settings"></ids-icon>
-        <span slot="text"></span>
+        <ids-icon icon="settings"></ids-icon>
+        <span></span>
       </ids-toggle-button>
     </ids-layout-grid-cell>
   </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-toolbar/demos/centered/centered.component.html
+++ b/angular-ids-wc/src/app/components/ids-toolbar/demos/centered/centered.component.html
@@ -10,14 +10,14 @@
       <ids-toolbar>
         <ids-toolbar-section>
           <ids-button icon="menu" role="button">
-            <span slot="text" class="audible">Application Menu Trigger</span>
+            <span class="audible">Application Menu Trigger</span>
           </ids-button>
         </ids-toolbar-section>
       
         <ids-toolbar-section type="buttonset" align="center">
           <ids-button id="button-1" role="button">
-            <span class="audible" slot="text">About Infor</span>
-            <ids-icon slot="icon" viewbox="0 0 35 34" icon="logo"></ids-icon>
+            <span class="audible">About Infor</span>
+            <ids-icon viewbox="0 0 35 34" icon="logo"></ids-icon>
           </ids-button>
         </ids-toolbar-section>
       

--- a/angular-ids-wc/src/app/components/ids-toolbar/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-toolbar/demos/example/example.component.html
@@ -10,7 +10,7 @@
       <ids-toolbar id="my-toolbar">
         <ids-toolbar-section>
           <ids-button icon="menu" role="button">
-            <span slot="text" class="audible">Application Menu Trigger</span>
+            <span class="audible">Application Menu Trigger</span>
           </ids-button>
         </ids-toolbar-section>
         <ids-toolbar-section type="title" favor>
@@ -19,17 +19,17 @@
         </ids-toolbar-section>
         <ids-toolbar-section type="buttonset" align="end">
           <ids-button id="button-1" role="button" no-padding>
-            <span slot="text">Text 1</span>
+            <span>Text 1</span>
           </ids-button>
           <ids-button id="button-2" role="button" no-padding>
-            <span slot="text">Text 2</span>
+            <span>Text 2</span>
           </ids-button>
           <ids-button id="button-3" role="button" no-padding>
-            <span slot="text">Text 3</span>
+            <span>Text 3</span>
           </ids-button>
       
           <ids-menu-button role="button" id="button-4" menu="button-4-menu" dropdown-icon no-padding>
-            <span slot="text">Menu</span>
+            <span>Menu</span>
           </ids-menu-button>
           <ids-popup-menu id="button-4-menu" target="#button-4">
             <ids-menu-group>
@@ -49,13 +49,13 @@
           </ids-popup-menu>
       
           <ids-button id="button-5" disabled>
-            <span slot="text" class="audible">Settings</span>
-            <ids-icon slot="icon" icon="settings"></ids-icon>
+            <span class="audible">Settings</span>
+            <ids-icon icon="settings"></ids-icon>
           </ids-button>
       
           <ids-button id="button-6">
-            <span slot="text" class="audible">Trash</span>
-            <ids-icon slot="icon" icon="delete"></ids-icon>
+            <span class="audible">Trash</span>
+            <ids-icon icon="delete"></ids-icon>
           </ids-button>
         </ids-toolbar-section>
       

--- a/angular-ids-wc/src/app/components/ids-toolbar/demos/overflowed/overflowed.component.html
+++ b/angular-ids-wc/src/app/components/ids-toolbar/demos/overflowed/overflowed.component.html
@@ -10,7 +10,7 @@
         <ids-toolbar>
           <ids-toolbar-section>
             <ids-button icon="menu" role="button">
-              <span slot="text" class="audible">Application Menu Trigger</span>
+              <span class="audible">Application Menu Trigger</span>
             </ids-button>
           </ids-toolbar-section>
           <ids-toolbar-section type="title" favor>
@@ -19,11 +19,11 @@
           </ids-toolbar-section>
           <ids-toolbar-section type="buttonset" align="end">
             <ids-button id="button-1" role="button">
-              <span slot="text">Text Button 1</span>
+              <span>Text Button 1</span>
             </ids-button>
         
             <ids-menu-button role="button" id="button-2" menu="button-2-menu" dropdown-icon>
-              <span slot="text">Menu Button 2</span>
+              <span>Menu Button 2</span>
             </ids-menu-button>
             <ids-popup-menu id="button-2-menu" target="#button-2">
               <ids-menu-group>
@@ -43,17 +43,17 @@
             </ids-popup-menu>
         
             <ids-button id="button-3" disabled>
-              <span slot="text">Icon Button 3</span>
-              <ids-icon slot="icon" icon="settings"></ids-icon>
+              <span>Icon Button 3</span>
+              <ids-icon icon="settings"></ids-icon>
             </ids-button>
         
             <ids-button id="button-4">
-              <span slot="text">Icon Button 4</span>
-              <ids-icon slot="icon" icon="delete"></ids-icon>
+              <span>Icon Button 4</span>
+              <ids-icon icon="delete"></ids-icon>
             </ids-button>
         
             <ids-button id="button-5" disabled>
-              <span slot="text">Text Button 5</span>
+              <span>Text Button 5</span>
             </ids-button>
           </ids-toolbar-section>
         

--- a/angular-ids-wc/src/app/components/ids-tree/demos/sandbox/sandbox.component.html
+++ b/angular-ids-wc/src/app/components/ids-tree/demos/sandbox/sandbox.component.html
@@ -52,7 +52,7 @@
         <ids-radio value="collapse-all" label="Collapse All" checked="true"></ids-radio>
       </ids-radio-group>
       <ids-button id="btn-tree-expandcollapse" type="secondary">
-        <span slot="text">Expand/Collapse Action</span>
+        <span>Expand/Collapse Action</span>
       </ids-button>
       <br/><br/>
       <ids-tree id="tree-expand-or-collapse" label="Tree Expand or Collapse"></ids-tree>
@@ -64,7 +64,7 @@
       <ids-text font-size="12" type="h2">Selection</ids-text>
       <br/>
       <ids-button id="btn-tree-toggle-selection" type="secondary">
-        <span slot="text">Toggle Selection (Public Folders)</span>
+        <span>Toggle Selection (Public Folders)</span>
       </ids-button>
       <br/><br/>
       <ids-tree id="tree-selection" label="Tree Selection"></ids-tree>
@@ -76,7 +76,7 @@
       <ids-text font-size="12" type="h2">Disable / Enable</ids-text>
       <br/>
       <ids-button id="btn-tree-disable-enable" type="secondary">
-        <span slot="text">Enable Tree</span>
+        <span>Enable Tree</span>
       </ids-button>
       <br/><br/>
       <ids-tree id="tree-disable-enable" label="Tree Disable and Enable"></ids-tree>

--- a/angular-ids-wc/src/app/components/ids-trigger-field/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-trigger-field/demos/example/example.component.html
@@ -10,14 +10,14 @@
       <ids-trigger-field id="trigger-field-1" size="sm" tabbable="false" label="Date Field">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Date Field trigger</ids-text>
-          <ids-icon slot="icon" icon="schedule"></ids-icon>
+          <ids-icon icon="schedule"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
 
       <ids-trigger-field disabled id="trigger-field-4" size="md" label="Disabled Trigger Field" value="Enter Album Name">
         <ids-trigger-button slot="trigger-end" disabled>
           <ids-text audible="true">Select Image</ids-text>
-          <ids-icon slot="icon" icon="camera"></ids-icon>
+          <ids-icon icon="camera"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
     </ids-layout-grid-cell>
@@ -26,18 +26,18 @@
       <ids-trigger-field id="trigger-field-2" label="Timepicker" size="md" type="text">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Timepicker trigger</ids-text>
-          <ids-icon slot="icon" icon="clock"></ids-icon>
+          <ids-icon icon="clock"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
 
       <ids-trigger-field id="trigger-field-5" label="Two Trigger Buttons" placeholder="Enter Product" size="md">
         <ids-trigger-button slot="trigger-start">
           <ids-text audible="true">Products left trigger button</ids-text>
-          <ids-icon slot="icon" icon="caret-down"></ids-icon>
+          <ids-icon icon="caret-down"></ids-icon>
         </ids-trigger-button>
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Products right trigger button</ids-text>
-          <ids-icon slot="icon" icon="caret-down"></ids-icon>
+          <ids-icon icon="caret-down"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
     </ids-layout-grid-cell>
@@ -46,14 +46,14 @@
       <ids-trigger-field id="trigger-field-3" label="Photos" placeholder="Enter Album Name" validate="required">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Select Image</ids-text>
-          <ids-icon slot="icon" icon="camera"></ids-icon>
+          <ids-icon icon="camera"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
 
       <ids-trigger-field id="trigger-field-6" placeholder="Type an input..." size="md" label="Read-only Trigger Field" readonly>
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Read-only Trigger Button</ids-text>
-          <ids-icon slot="icon" icon="rename"></ids-icon>
+          <ids-icon icon="rename"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
     </ids-layout-grid-cell>
@@ -69,7 +69,7 @@
       >
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Autocomplete Trigger Field</ids-text>
-          <ids-icon slot="icon" icon="camera"></ids-icon>
+          <ids-icon icon="camera"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
     </ids-layout-grid-cell>

--- a/angular-ids-wc/src/app/components/ids-trigger-field/demos/label-state/label-state.component.html
+++ b/angular-ids-wc/src/app/components/ids-trigger-field/demos/label-state/label-state.component.html
@@ -6,7 +6,7 @@
       <ids-trigger-field id="trigger-field-1" placeholder="This trigger field's label is visible" size="md" label="Regular Trigger Field">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Trigger button on hidden-label trigger field</ids-text>
-          <ids-icon slot="icon" icon="launch"></ids-icon>
+          <ids-icon icon="launch"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
     </ids-layout-grid-cell>
@@ -15,7 +15,7 @@
       <ids-trigger-field id="trigger-field-2" placeholder="This trigger field's label is 'hidden'" size="md" label="Trigger field with hidden label" label-state="hidden">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Trigger button on hidden-label trigger field</ids-text>
-          <ids-icon slot="icon" icon="launch"></ids-icon>
+          <ids-icon icon="launch"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
     </ids-layout-grid-cell>
@@ -24,7 +24,7 @@
       <ids-trigger-field id="trigger-field-3" placeholder="This trigger field's label is 'collapsed'" size="md" label="Trigger field with collapsed label" label-state="collapsed">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Trigger button on collapsed-label trigger field</ids-text>
-          <ids-icon slot="icon" icon="launch"></ids-icon>
+          <ids-icon icon="launch"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
     </ids-layout-grid-cell>

--- a/angular-ids-wc/src/app/components/ids-trigger-field/demos/text-sizes/text-sizes.component.html
+++ b/angular-ids-wc/src/app/components/ids-trigger-field/demos/text-sizes/text-sizes.component.html
@@ -13,14 +13,14 @@
       <ids-trigger-field label="Basic">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Date Field trigger</ids-text>
-          <ids-icon slot="icon" icon="schedule"></ids-icon>
+          <ids-icon icon="schedule"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
 
       <ids-trigger-field label="Compact" compact>
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Date Field trigger</ids-text>
-          <ids-icon slot="icon" icon="schedule"></ids-icon>
+          <ids-icon icon="schedule"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
 
@@ -40,28 +40,28 @@
       <ids-trigger-field label="Extra Small (compact)" field-height="xs">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Date Field trigger</ids-text>
-          <ids-icon slot="icon" icon="schedule"></ids-icon>
+          <ids-icon icon="schedule"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
 
       <ids-trigger-field label="Small" field-height="sm">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Date Field trigger</ids-text>
-          <ids-icon slot="icon" icon="schedule"></ids-icon>
+          <ids-icon icon="schedule"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
 
       <ids-trigger-field label="Medium (default)" field-height="md">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Date Field trigger</ids-text>
-          <ids-icon slot="icon" icon="schedule"></ids-icon>
+          <ids-icon icon="schedule"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
 
       <ids-trigger-field label="Large" field-height="lg">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Date Field trigger</ids-text>
-          <ids-icon slot="icon" icon="schedule"></ids-icon>
+          <ids-icon icon="schedule"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
 
@@ -81,42 +81,42 @@
       <ids-trigger-field size="xs" label="Extra Small">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Date Field trigger</ids-text>
-          <ids-icon slot="icon" icon="schedule"></ids-icon>
+          <ids-icon icon="schedule"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
 
       <ids-trigger-field size="sm" label="Small">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Date Field trigger</ids-text>
-          <ids-icon slot="icon" icon="schedule"></ids-icon>
+          <ids-icon icon="schedule"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
 
       <ids-trigger-field size="mm" label="Small - Medium">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Date Field trigger</ids-text>
-          <ids-icon slot="icon" icon="schedule"></ids-icon>
+          <ids-icon icon="schedule"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
 
       <ids-trigger-field size="md" label="Medium (default)">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Date Field trigger</ids-text>
-          <ids-icon slot="icon" icon="schedule"></ids-icon>
+          <ids-icon icon="schedule"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
 
       <ids-trigger-field size="lg" label="Large">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Date Field trigger</ids-text>
-          <ids-icon slot="icon" icon="schedule"></ids-icon>
+          <ids-icon icon="schedule"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
 
       <ids-trigger-field size="full" label="Full">
         <ids-trigger-button slot="trigger-end">
           <ids-text audible="true">Date Field trigger</ids-text>
-          <ids-icon slot="icon" icon="schedule"></ids-icon>
+          <ids-icon icon="schedule"></ids-icon>
         </ids-trigger-button>
       </ids-trigger-field>
 

--- a/angular-ids-wc/src/app/components/ids-upload-advanced/demos/sandbox/sandbox.component.html
+++ b/angular-ids-wc/src/app/components/ids-upload-advanced/demos/sandbox/sandbox.component.html
@@ -115,7 +115,7 @@
 
     <ids-layout-grid-cell>
       <ids-button id="upload-advanced-set-error-btn" type="secondary">
-        <span slot="text">Set Error</span>
+        <span>Set Error</span>
       </ids-button>
       <ids-text font-size="12">Arbitrary error message</ids-text>
       <ids-upload-advanced id="upload-advanced-set-error" url="http://localhost:4300/upload"></ids-upload-advanced>
@@ -126,7 +126,7 @@
 
     <ids-layout-grid-cell>
       <ids-button id="upload-advanced-set-error-on-files-btn" type="secondary">
-        <span slot="text">Set Error on each file</span>
+        <span>Set Error on each file</span>
       </ids-button>
       <ids-text font-size="14">Add file/s to upload before apply error. It can only be apply before `completed` state.</ids-text><br />
       <ids-text font-size="12">Arbitrary error message (set on files)</ids-text>

--- a/react-ids-wc/src/examples/ids-accordion/index.js
+++ b/react-ids-wc/src/examples/ids-accordion/index.js
@@ -57,7 +57,7 @@ const IdsAccordion = () => {
             type="primary"
             onClick={() => setExpanded(!expanded)}
           >
-            <span slot="text">{!expanded ? 'Expand All' : 'Collapse All'}</span>
+            <span>{!expanded ? 'Expand All' : 'Collapse All'}</span>
           </ids-button>
         </ids-layout-grid-cell>
       </ids-layout-grid>

--- a/react-ids-wc/src/examples/ids-action-sheet/index.js
+++ b/react-ids-wc/src/examples/ids-action-sheet/index.js
@@ -23,7 +23,7 @@ const IdsActionSheet = () => {
               actionSheetRef.current.visible = !actionSheetRef.current.visible;
             }}
           >
-            <ids-icon slot="icon" icon="more"></ids-icon>
+            <ids-icon icon="more"></ids-icon>
             <span className="audible">Icon Only Button</span>
           </ids-menu-button>
 
@@ -36,15 +36,15 @@ const IdsActionSheet = () => {
             <ids-menu-group>
               <ids-menu-item>
                 Option One
-                <ids-icon slot="icon" icon="mail"></ids-icon>
+                <ids-icon icon="mail"></ids-icon>
               </ids-menu-item>
               <ids-menu-item>
                 Option Two
-                <ids-icon slot="icon" icon="filter"></ids-icon>
+                <ids-icon icon="filter"></ids-icon>
               </ids-menu-item>
               <ids-menu-item>
                 Option Three
-                <ids-icon slot="icon" icon="profile"></ids-icon>
+                <ids-icon icon="profile"></ids-icon>
               </ids-menu-item>
             </ids-menu-group>
           </ids-popup-menu>

--- a/react-ids-wc/src/examples/ids-alert/index.js
+++ b/react-ids-wc/src/examples/ids-alert/index.js
@@ -26,13 +26,13 @@ const IdsAlert = () => {
       <ids-layout-grid cols="12" gap="md">
         <ids-layout-grid-cell>
           <ids-button type="secondary" onClick={() => setItems(items.slice(0, -1))}>
-            <span slot="text">Remove item</span>
+            <span>Remove item</span>
           </ids-button>
         </ids-layout-grid-cell>
 
         <ids-layout-grid-cell>
           <ids-button type="secondary" onClick={() => setItems(data)}>
-            <span slot="text">Reset</span>
+            <span>Reset</span>
           </ids-button>
         </ids-layout-grid-cell>
       </ids-layout-grid>

--- a/react-ids-wc/src/examples/ids-app-menu/index.js
+++ b/react-ids-wc/src/examples/ids-app-menu/index.js
@@ -14,7 +14,7 @@ const IdsAppMenu = () => {
             <ids-button icon="menu" onClick={() => {
               appMenuRef.current.visible = !appMenuRef.current.visible;
             }}>
-              <span slot="text" className="audible">
+              <span className="audible">
                 Open App Menu
               </span>
             </ids-button>
@@ -39,27 +39,27 @@ const IdsAppMenu = () => {
         <ids-toolbar slot="header">
           <ids-toolbar-section align="center-even" type="buttonset">
             <ids-button id="header-btn-download" icon="download">
-              <ids-text slot="text" audible>
+              <ids-text audible>
                 Download
               </ids-text>
             </ids-button>
             <ids-button id="header-btn-print" icon="print">
-              <ids-text slot="text" audible>
+              <ids-text audible>
                 Print
               </ids-text>
             </ids-button>
             <ids-button id="header-btn-purchasing" icon="purchasing">
-              <ids-text slot="text" audible>
+              <ids-text audible>
                 Purchasing
               </ids-text>
             </ids-button>
             <ids-button id="header-btn-notification" icon="notification">
-              <ids-text slot="text" audible>
+              <ids-text audible>
                 Notification
               </ids-text>
             </ids-button>
             <ids-button id="header-btn-inventory" icon="inventory">
-              <ids-text slot="text" audible>
+              <ids-text audible>
                 Inventory
               </ids-text>
             </ids-button>

--- a/react-ids-wc/src/examples/ids-button/index.js
+++ b/react-ids-wc/src/examples/ids-button/index.js
@@ -36,13 +36,13 @@ const IdsButton = () => {
               e.target.text = 'Clicked';
             }}
           >
-            <span slot="text">React onClick synthetic event</span>
+            <span>React onClick synthetic event</span>
           </ids-button>
         </ids-layout-grid-cell>
 
         <ids-layout-grid-cell>
           <ids-button type="secondary" ref={buttonRef}>
-            <span slot="text">Manually attached event listener</span>
+            <span>Manually attached event listener</span>
           </ids-button>
         </ids-layout-grid-cell>
       </ids-layout-grid>

--- a/react-ids-wc/src/examples/ids-checkbox/index.js
+++ b/react-ids-wc/src/examples/ids-checkbox/index.js
@@ -86,10 +86,10 @@ const IdsCheckbox = () => {
             indeterminate={indeterminate}
           ></ids-checkbox>
           <ids-button type="primary" onClick={() => setIndeterminate(true)}>
-            <span slot="text">Set</span>
+            <span>Set</span>
           </ids-button>
           <ids-button type="secondary" onClick={() => setIndeterminate(false)}>
-            <span slot="text">Remove</span>
+            <span>Remove</span>
           </ids-button>
 
           <br />

--- a/react-ids-wc/src/examples/ids-empty-message/index.js
+++ b/react-ids-wc/src/examples/ids-empty-message/index.js
@@ -27,7 +27,7 @@ const IdsEmptyMessage = () => {
                   Description of empty message that explains why and possible contain a hyperlink.
                 </ids-text>
                 <ids-button class="action-button" slot="button" type="primary">
-                  <span slot="text">Action</span>
+                  <span>Action</span>
                 </ids-button>
               </ids-empty-message>
             </div>

--- a/react-ids-wc/src/examples/ids-expandable-area/index.js
+++ b/react-ids-wc/src/examples/ids-expandable-area/index.js
@@ -130,7 +130,7 @@ const IdsExpandableArea = () => {
               icon-align="start"
             >
               <ids-icon slot="icon" icon="caret-up"></ids-icon>
-              <span slot="text">Default Button</span>
+              <span>Default Button</span>
             </ids-toggle-button>
             <ids-text slot="pane" font-size="14">
               Ubiquitous out-of-the-box, scalable; communities disintermediate

--- a/react-ids-wc/src/examples/ids-form/index.js
+++ b/react-ids-wc/src/examples/ids-form/index.js
@@ -143,7 +143,7 @@ const IdsForm = () => {
               field-height={height}
             ></ids-textarea>
             <ids-button id="btn-submit" type="primary">
-              <span slot="text">Submit</span>
+              <span>Submit</span>
             </ids-button>
           </ids-layout-grid-cell>
           <ids-layout-grid-cell>
@@ -271,7 +271,7 @@ const IdsForm = () => {
             modalRef.current?.hide();
           }}
         >
-          <span slot="text">OK</span>
+          <span>OK</span>
         </ids-modal-button>
       </ids-modal>
     </>

--- a/react-ids-wc/src/examples/ids-header/index.js
+++ b/react-ids-wc/src/examples/ids-header/index.js
@@ -14,7 +14,7 @@ const IdsHeader = () => {
         <ids-toolbar>
           <ids-toolbar-section type="button">
             <ids-button icon="menu" role="button">
-              <span slot="text" className="audible">
+              <span className="audible">
                 Application Menu Trigger
               </span>
             </ids-button>

--- a/react-ids-wc/src/examples/ids-hierarchy/index.js
+++ b/react-ids-wc/src/examples/ids-hierarchy/index.js
@@ -45,7 +45,7 @@ const IdsHierarchy = () => {
                 id="item-menu-btn-id-one"
               >
                 <span className="audible">Popup Menu Button</span>
-                <ids-icon slot="icon" icon="more"></ids-icon>
+                <ids-icon icon="more"></ids-icon>
               </ids-menu-button>
               <ids-popup-menu
                 id="item-menu-id-one"
@@ -71,7 +71,7 @@ const IdsHierarchy = () => {
                   id="item-menu-btn-id-two"
                 >
                   <span className="audible">Popup Menu Button</span>
-                  <ids-icon slot="icon" icon="more"></ids-icon>
+                  <ids-icon icon="more"></ids-icon>
                 </ids-menu-button>
                 <ids-popup-menu
                   id="item-menu-id-two"
@@ -107,7 +107,7 @@ const IdsHierarchy = () => {
                   id="item-menu-btn-id-three"
                 >
                   <span className="audible">Popup Menu Button</span>
-                  <ids-icon slot="icon" icon="more"></ids-icon>
+                  <ids-icon icon="more"></ids-icon>
                 </ids-menu-button>
                 <ids-popup-menu
                   id="item-menu-id-three"

--- a/react-ids-wc/src/examples/ids-input/index.js
+++ b/react-ids-wc/src/examples/ids-input/index.js
@@ -128,13 +128,13 @@ const IdsInput = () => {
           ></ids-input>
 
           <ids-button id="btn-input-enable" type="secondary">
-            <span slot="text">Enable</span>
+            <span>Enable</span>
           </ids-button>
           <ids-button id="btn-input-disable" type="secondary">
-            <span slot="text">Disable</span>
+            <span>Disable</span>
           </ids-button>
           <ids-button id="btn-input-readonly" type="secondary">
-            <span slot="text">Readonly</span>
+            <span>Readonly</span>
           </ids-button>
         </ids-layout-grid-cell>
       </ids-layout-grid>

--- a/react-ids-wc/src/examples/ids-lookup/index.js
+++ b/react-ids-wc/src/examples/ids-lookup/index.js
@@ -127,7 +127,7 @@ const IdsLookup = () => {
                 id="modal-cancel-btn"
                 type="primary"
               >
-                <span slot="text">Apply</span>
+                <span>Apply</span>
               </ids-modal-button>
             </ids-modal>
           </ids-lookup> */}

--- a/react-ids-wc/src/examples/ids-masthead/index.js
+++ b/react-ids-wc/src/examples/ids-masthead/index.js
@@ -17,35 +17,35 @@ const IdsMasthead = () => {
           <ids-masthead title="Infor Application" icon="logo" role="navigation">
             <section title="start" slot="start">
               <ids-button icon="grid">
-                <span slot="text" className="audible">
+                <span className="audible">
                   Grid Button
                 </span>
               </ids-button>
             </section>
             <section title="center" slot="center">
               <ids-button icon="home">
-                <span slot="text">Home</span>
+                <span>Home</span>
               </ids-button>
               <ids-button icon="star-outlined">
-                <span slot="text">Star</span>
+                <span>Star</span>
               </ids-button>
               <ids-button icon="info">
-                <span slot="text">Info</span>
+                <span>Info</span>
               </ids-button>
             </section>
             <section title="end" slot="end">
               <ids-button icon="user">
-                <span slot="text" className="audible">
+                <span className="audible">
                   User Button
                 </span>
               </ids-button>
               <ids-button icon="mingle-share">
-                <span slot="text" className="audible">
+                <span className="audible">
                   Mingle Button
                 </span>
               </ids-button>
               <ids-button icon="bookmark-outlined">
-                <span slot="text" className="audible">
+                <span className="audible">
                   Bookmark Button
                 </span>
               </ids-button>

--- a/react-ids-wc/src/examples/ids-menu-button/index.js
+++ b/react-ids-wc/src/examples/ids-menu-button/index.js
@@ -12,7 +12,7 @@ const IdsMenuButton = () => {
       <ids-layout-grid cols="4" gap="md">
         <ids-layout-grid-cell>
           <ids-menu-button id="menu-button" icon="settings" type="tertiary" menu="my-menu" dropdown-icon="dropdown">
-            <span slot="text">Settings</span>
+            <span>Settings</span>
           </ids-menu-button>
           <ids-popup-menu id="my-menu" target="#menu-button" trigger-type="click">
             <ids-menu-group>

--- a/react-ids-wc/src/examples/ids-modal/index.js
+++ b/react-ids-wc/src/examples/ids-modal/index.js
@@ -18,7 +18,7 @@ const IdsModal = () => {
             modalRef.current?.hide()
           }}
         >
-          <span slot="text">OK</span>
+          <span>OK</span>
         </ids-modal-button>
         <ids-text type="p">This is an active IDS Modal component</ids-text>
       </ids-modal>
@@ -38,7 +38,7 @@ const IdsModal = () => {
             }}
             disabled={modalRef.current?.visible}
           >
-            <span slot="text">Trigger a Modal</span>
+            <span>Trigger a Modal</span>
           </ids-button>
         </ids-layout-grid-cell>
       </ids-layout-grid>

--- a/react-ids-wc/src/examples/ids-pager/index.js
+++ b/react-ids-wc/src/examples/ids-pager/index.js
@@ -39,7 +39,7 @@ const IdsPager = () => {
               pagerRef.current?.setAttribute('disabled', String(!pagerRef.current.disabled))
             }}
           >
-            <span slot="text">Disable</span>
+            <span>Disable</span>
           </ids-button>
         </ids-layout-grid-cell>
       </ids-layout-grid>

--- a/react-ids-wc/src/examples/ids-popup/index.js
+++ b/react-ids-wc/src/examples/ids-popup/index.js
@@ -37,7 +37,7 @@ const IdsPopup = () => {
       <ids-layout-grid auto="true">
         <ids-layout-grid-cell>
           <ids-button type="secondary" ref={triggerRef}>
-            <span slot="text">Trigger a Popup</span>
+            <span>Trigger a Popup</span>
           </ids-button>
         </ids-layout-grid-cell>
       </ids-layout-grid>

--- a/react-ids-wc/src/examples/ids-progress-bar/index.js
+++ b/react-ids-wc/src/examples/ids-progress-bar/index.js
@@ -82,7 +82,7 @@ const IdsProgressBar = () => {
             text-off="Update Value"
             text-on="Reset Value"
           >
-            <span slot="text"></span>
+            <span></span>
           </ids-toggle-button>
 
           <ids-toggle-button
@@ -92,7 +92,7 @@ const IdsProgressBar = () => {
             text-off="Disable"
             text-on="Enable"
           >
-            <span slot="text"></span>
+            <span></span>
           </ids-toggle-button>
 
           <ids-toggle-button
@@ -102,7 +102,7 @@ const IdsProgressBar = () => {
             text-off="Audible label"
             text-on="Inaudible label"
           >
-            <span slot="text"></span>
+            <span></span>
           </ids-toggle-button>
         </ids-layout-grid-cell>
 

--- a/react-ids-wc/src/examples/ids-radio/index.js
+++ b/react-ids-wc/src/examples/ids-radio/index.js
@@ -132,10 +132,10 @@ const IdsRadio = () => {
             ></ids-radio>
           </ids-radio-group>
           <ids-button type="secondary" onClick={() => radioGroupRef.current.clear()}>
-            <span slot="text">Clear</span>
+            <span>Clear</span>
           </ids-button>
           <ids-button type="secondary" onClick={() => radioGroupRef.current.checkValidation()}>
-            <span slot="text">Validate</span>
+            <span>Validate</span>
           </ids-button>
 
           <br />

--- a/react-ids-wc/src/examples/ids-search-field/index.js
+++ b/react-ids-wc/src/examples/ids-search-field/index.js
@@ -79,7 +79,7 @@ const IdsSearchField = () => {
             <ids-toolbar>
               <ids-toolbar-section type="button">
                 <ids-button icon="menu" role="button">
-                  <span slot="text" className="audible">
+                  <span className="audible">
                     Application Menu Trigger
                   </span>
                 </ids-button>

--- a/react-ids-wc/src/examples/ids-swipe-action/index.js
+++ b/react-ids-wc/src/examples/ids-swipe-action/index.js
@@ -55,7 +55,7 @@ const IdsSwipeAction = () => {
                   type="swipe-action-right"
                 >
                   <ids-icon slot="icon" icon="tack" size="xsmall"></ids-icon>
-                  <span slot="text">Right Action</span>
+                  <span>Right Action</span>
                 </ids-button>
               </ids-swipe-action>
             </div>
@@ -79,7 +79,7 @@ const IdsSwipeAction = () => {
                   type="swipe-action-left"
                 >
                   <ids-icon slot="icon" icon="reply" size="xsmall"></ids-icon>
-                  <span slot="text">Left Action</span>
+                  <span>Left Action</span>
                 </ids-button>
                 <div slot="contents">
                   <ids-layout-grid cols="2" no-margins="true">
@@ -121,7 +121,7 @@ const IdsSwipeAction = () => {
                   type="swipe-action-right"
                 >
                   <ids-icon slot="icon" icon="tack" size="xsmall"></ids-icon>
-                  <span slot="text">Right Action</span>
+                  <span>Right Action</span>
                 </ids-button>
               </ids-swipe-action>
             </div>
@@ -145,7 +145,7 @@ const IdsSwipeAction = () => {
                   type="swipe-action-left"
                 >
                   <ids-icon slot="icon" icon="reply" size="xsmall"></ids-icon>
-                  <span slot="text">Left Action</span>
+                  <span>Left Action</span>
                 </ids-button>
                 <div slot="contents">
                   <ids-layout-grid cols="2" no-margins="true">
@@ -187,7 +187,7 @@ const IdsSwipeAction = () => {
                   type="swipe-action-right"
                 >
                   <ids-icon slot="icon" icon="tack" size="xsmall"></ids-icon>
-                  <span slot="text">Right Action</span>
+                  <span>Right Action</span>
                 </ids-button>
               </ids-swipe-action>
             </div>

--- a/react-ids-wc/src/examples/ids-textarea/index.js
+++ b/react-ids-wc/src/examples/ids-textarea/index.js
@@ -54,13 +54,13 @@ const IdsTextarea = () => {
             Line One
           </ids-textarea>
           <ids-button id="btn-textarea-enable" type="secondary">
-            <span slot="text">Enable</span>
+            <span>Enable</span>
           </ids-button>
           <ids-button id="btn-textarea-disable" type="secondary">
-            <span slot="text">Disable</span>
+            <span>Disable</span>
           </ids-button>
           <ids-button id="btn-textarea-readonly" type="secondary">
-            <span slot="text">Readonly</span>
+            <span>Readonly</span>
           </ids-button>
         </ids-layout-grid-cell>
         <ids-layout-grid-cell>
@@ -68,10 +68,10 @@ const IdsTextarea = () => {
             Line One
           </ids-textarea>
           <ids-button id="btn-textarea-update-value" type="secondary">
-            <span slot="text">Update Value</span>
+            <span>Update Value</span>
           </ids-button>
           <ids-button id="btn-textarea-reset-value" type="secondary">
-            <span slot="text">Reset Value</span>
+            <span>Reset Value</span>
           </ids-button>
         </ids-layout-grid-cell>
       </ids-layout-grid>

--- a/react-ids-wc/src/examples/ids-toast/index.js
+++ b/react-ids-wc/src/examples/ids-toast/index.js
@@ -28,7 +28,7 @@ const IdsToast = () => {
       <ids-layout-grid auto="true">
         <ids-layout-grid-cell>
           <ids-button onClick={handleToastAdd} type="secondary">
-            <span slot="text">Toast Message</span>
+            <span>Toast Message</span>
           </ids-button>
         </ids-layout-grid-cell>
       </ids-layout-grid>

--- a/react-ids-wc/src/examples/ids-toggle-button/index.js
+++ b/react-ids-wc/src/examples/ids-toggle-button/index.js
@@ -19,8 +19,8 @@ const IdsToggleButton = () => {
             text-off="Toggle Button (Off)"
             text-on="Toggle Button (On)"
           >
-            <ids-icon slot="icon" icon="settings"></ids-icon>
-            <span slot="text"></span>
+            <ids-icon icon="settings"></ids-icon>
+            <span></span>
           </ids-toggle-button>
         </ids-layout-grid-cell>
       </ids-layout-grid>

--- a/react-ids-wc/src/examples/ids-toolbar/index.js
+++ b/react-ids-wc/src/examples/ids-toolbar/index.js
@@ -15,7 +15,7 @@ const IdsToolbar = () => {
           <ids-toolbar id="my-toolbar">
             <ids-toolbar-section type="button">
               <ids-button icon="menu" role="button">
-                <span slot="text" className="audible">
+                <span className="audible">
                   Application Menu Trigger
                 </span>
               </ids-button>
@@ -26,13 +26,13 @@ const IdsToolbar = () => {
             </ids-toolbar-section>
             <ids-toolbar-section type="buttonset" align="end">
               <ids-button id="button-1" role="button" no-padding>
-                <span slot="text">Text 1</span>
+                <span>Text 1</span>
               </ids-button>
               <ids-button id="button-2" role="button" no-padding>
-                <span slot="text">Text 2</span>
+                <span>Text 2</span>
               </ids-button>
               <ids-button id="button-3" role="button" no-padding>
-                <span slot="text">Text 3</span>
+                <span>Text 3</span>
               </ids-button>
 
               <ids-menu-button
@@ -43,7 +43,7 @@ const IdsToolbar = () => {
                 dropdown-icon="dropdown"
                 no-padding
               >
-                <span slot="text">Menu</span>
+                <span>Menu</span>
               </ids-menu-button>
               <ids-popup-menu id="button-4-menu" target="#button-4">
                 <ids-menu-group>
@@ -64,17 +64,17 @@ const IdsToolbar = () => {
               </ids-popup-menu>
 
               <ids-button id="button-5" disabled>
-                <span slot="text" className="audible">
+                <span className="audible">
                   Settings
                 </span>
-                <ids-icon slot="icon" icon="settings"></ids-icon>
+                <ids-icon icon="settings"></ids-icon>
               </ids-button>
 
               <ids-button id="button-6">
-                <span slot="text" className="audible">
+                <span className="audible">
                   Trash
                 </span>
-                <ids-icon slot="icon" icon="delete"></ids-icon>
+                <ids-icon icon="delete"></ids-icon>
               </ids-button>
             </ids-toolbar-section>
 

--- a/react-ids-wc/src/examples/ids-trigger-field/index.js
+++ b/react-ids-wc/src/examples/ids-trigger-field/index.js
@@ -20,7 +20,7 @@ const IdsTriggerField = () => {
         >
           <ids-trigger-button slot="trigger-end">
             <ids-text audible="true">Date Field trigger</ids-text>
-            <ids-icon slot="icon" icon="schedule"></ids-icon>
+            <ids-icon icon="schedule"></ids-icon>
           </ids-trigger-button>
         </ids-trigger-field>
 
@@ -28,7 +28,7 @@ const IdsTriggerField = () => {
           <ids-trigger-field id="trigger-field-2" size="md" label="Timepicker">
             <ids-trigger-button slot="trigger-end">
               <ids-text audible="true">Timepicker trigger</ids-text>
-              <ids-icon slot="icon" icon="clock"></ids-icon>
+              <ids-icon icon="clock"></ids-icon>
             </ids-trigger-button>
           </ids-trigger-field>
         </ids-layout-grid-cell>
@@ -42,7 +42,7 @@ const IdsTriggerField = () => {
           >
             <ids-trigger-button slot="trigger-end">
               <ids-text audible="true">Products trigger</ids-text>
-              <ids-icon slot="icon" icon="search-list"></ids-icon>
+              <ids-icon icon="search-list"></ids-icon>
             </ids-trigger-button>
           </ids-trigger-field>
         </ids-layout-grid-cell>
@@ -59,7 +59,7 @@ const IdsTriggerField = () => {
           >
             <ids-trigger-button disabled slot="trigger-end">
               <ids-text audible="true">Products trigger</ids-text>
-              <ids-icon slot="icon" icon="search-list"></ids-icon>
+              <ids-icon icon="search-list"></ids-icon>
             </ids-trigger-button>
           </ids-trigger-field>
         </ids-layout-grid-cell>
@@ -73,11 +73,11 @@ const IdsTriggerField = () => {
           >
             <ids-trigger-button slot="trigger-start">
               <ids-text audible="true">Products trigger</ids-text>
-              <ids-icon slot="icon" icon="caret-down"></ids-icon>
+              <ids-icon icon="caret-down"></ids-icon>
             </ids-trigger-button>
             <ids-trigger-button slot="trigger-end">
               <ids-text audible="true">Products trigger</ids-text>
-              <ids-icon slot="icon" icon="caret-down"></ids-icon>
+              <ids-icon icon="caret-down"></ids-icon>
             </ids-trigger-button>
           </ids-trigger-field>
         </ids-layout-grid-cell>
@@ -90,7 +90,7 @@ const IdsTriggerField = () => {
           >
             <ids-trigger-button>
               <ids-text audible="true">Search trigger</ids-text>
-              <ids-icon slot="icon" icon="search"></ids-icon>
+              <ids-icon icon="search"></ids-icon>
             </ids-trigger-button>
           </ids-trigger-field>
         </ids-layout-grid-cell>

--- a/sveltekit-ids-wc/src/routes/ids-action-sheet/example/+page.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-action-sheet/example/+page.svelte
@@ -35,7 +35,7 @@
   <ids-layout-grid-cell>
 
     <ids-menu-button id="icon-button" menu="icon-menu">
-      <ids-icon slot="icon" icon="more"></ids-icon>
+      <ids-icon icon="more"></ids-icon>
       <span class="audible">Icon Only Button</span>
     </ids-menu-button>
 

--- a/sveltekit-ids-wc/src/routes/ids-app-menu/example/+page.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-app-menu/example/+page.svelte
@@ -39,7 +39,7 @@
 <ids-layout-grid>
   <ids-layout-grid-cell>
     <ids-button id="app-menu-trigger" icon="menu">
-      <span slot="text" class="audible">Open App Menu</span>
+      <span class="audible">Open App Menu</span>
     </ids-button>
   </ids-layout-grid-cell>
 </ids-layout-grid>
@@ -53,19 +53,19 @@
   <ids-toolbar slot="header">
     <ids-toolbar-section align="center-even" type="fluid">
       <ids-button id="header-btn-download" icon="download">
-        <ids-text slot="text" audible>Download</ids-text>
+        <ids-text audible>Download</ids-text>
       </ids-button>
       <ids-button id="header-btn-print" icon="print">
-        <ids-text slot="text" audible>Print</ids-text>
+        <ids-text audible>Print</ids-text>
       </ids-button>
       <ids-button id="header-btn-purchasing" icon="purchasing">
-        <ids-text slot="text" audible>Purchasing</ids-text>
+        <ids-text audible>Purchasing</ids-text>
       </ids-button>
       <ids-button id="header-btn-notification" icon="notification">
-        <ids-text slot="text" audible>Notification</ids-text>
+        <ids-text audible>Notification</ids-text>
       </ids-button>
       <ids-button id="header-btn-inventory" icon="inventory">
-        <ids-text slot="text" audible>Inventory</ids-text>
+        <ids-text audible>Inventory</ids-text>
       </ids-button>
     </ids-toolbar-section>
   </ids-toolbar>

--- a/sveltekit-ids-wc/src/routes/ids-button/example/+page.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-button/example/+page.svelte
@@ -64,25 +64,25 @@
   <ids-layout-grid-cell>
     <ids-button id="icon-default-button" on:click={log}>
       <span class="audible">Default Button</span>
-      <ids-icon slot="icon" icon="settings"></ids-icon>
+      <ids-icon icon="settings"></ids-icon>
     </ids-button>
   </ids-layout-grid-cell>
   <ids-layout-grid-cell>
     <ids-button id="icon-primary-button" type="primary" on:click={log}>
       <span class="audible">Primary Button</span>
-      <ids-icon slot="icon" icon="settings"></ids-icon>
+      <ids-icon icon="settings"></ids-icon>
     </ids-button>
   </ids-layout-grid-cell>
   <ids-layout-grid-cell>
     <ids-button id="icon-secondary-button" type="secondary" on:click={log}>
       <span class="audible">Secondary Button</span>
-      <ids-icon slot="icon" icon="settings"></ids-icon>
+      <ids-icon icon="settings"></ids-icon>
     </ids-button>
   </ids-layout-grid-cell>
   <ids-layout-grid-cell>
     <ids-button id="icon-tertiary-button" type="tertiary" on:click={log}>
       <span class="audible">Tertiary Button</span>
-      <ids-icon slot="icon" icon="settings"></ids-icon>
+      <ids-icon icon="settings"></ids-icon>
     </ids-button>
   </ids-layout-grid-cell>
 </ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-modal/example/+page.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-modal/example/+page.svelte
@@ -36,7 +36,7 @@
 <ids-modal id="my-modal" aria-labelledby="my-modal-title">
   <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
   <ids-modal-button slot="buttons" id="modal-close-btn" type="primary">
-    <span slot="text">OK</span>
+    <span>OK</span>
   </ids-modal-button>
   <ids-text text-align="start">This is an active IDS Modal component</ids-text>
 </ids-modal>
@@ -48,7 +48,7 @@
 <ids-layout-grid auto="true">
   <ids-layout-grid-cell>
     <ids-button id="modal-trigger-btn" type="secondary">
-      <span slot="text">Trigger a Modal</span>
+      <span>Trigger a Modal</span>
     </ids-button>
   </ids-layout-grid-cell>
 </ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-popup/example/+page.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-popup/example/+page.svelte
@@ -34,7 +34,7 @@
 <ids-layout-grid auto="true">
   <ids-layout-grid-cell>
     <ids-button id="popup-trigger-btn" type="secondary">
-      <span slot="text">Trigger a Popup</span>
+      <span>Trigger a Popup</span>
     </ids-button>
   </ids-layout-grid-cell>
 </ids-layout-grid>

--- a/sveltekit-ids-wc/src/routes/ids-textarea/example/+page.svelte
+++ b/sveltekit-ids-wc/src/routes/ids-textarea/example/+page.svelte
@@ -74,22 +74,22 @@
   <ids-layout-grid-cell>
     <ids-textarea label="Toggle State" id="textarea-toggle-state">Line One</ids-textarea>
     <ids-button id="btn-textarea-enable" type="secondary">
-      <span slot="text">Enable</span>
+      <span>Enable</span>
     </ids-button>
     <ids-button id="btn-textarea-disable" type="secondary">
-      <span slot="text">Disable</span>
+      <span>Disable</span>
     </ids-button>
     <ids-button id="btn-textarea-readonly" type="secondary">
-      <span slot="text">Readonly</span>
+      <span>Readonly</span>
     </ids-button>
   </ids-layout-grid-cell>
   <ids-layout-grid-cell>
     <ids-textarea label="Update Value" id="textarea-update-value">Line One</ids-textarea>
     <ids-button id="btn-textarea-update-value" type="secondary">
-      <span slot="text">Update Value</span>
+      <span>Update Value</span>
     </ids-button>
     <ids-button id="btn-textarea-reset-value" type="secondary">
-      <span slot="text">Reset Value</span>
+      <span>Reset Value</span>
     </ids-button>
   </ids-layout-grid-cell>
 </ids-layout-grid>


### PR DESCRIPTION
**What's in the PR:**

This PR simply updates the existing examples of IdsButton/related components to support the settings changes in these PRs from the WC repo:

- https://github.com/infor-design/enterprise-wc/pull/1066
- https://github.com/infor-design/enterprise-wc/pull/1080
- https://github.com/infor-design/enterprise-wc/pull/1086

This PR doesn't add any new examples (we are still missing destructive states), but just brings what we currently ship in line with new designs/usage guidelines

**Related issues:**

- infor-design/enterprise-wc#839
- infor-design/enterprise-wc#1046

**How to test:**

- Use `npm run publish:link` to build a local copy of the current [IDS Enterprise Web Components repo](https://github.com/infor-design/enterprise-wc).
- In the example library you want to test (Angular/React/Sveltekit), run `npm link ids-enterprise-wc` to use this local copy instead of the beta from NPM
- Use `npm start` to try each repo.  Use the list of examples below to smoke test each respective framework.  All button examples should reflect the new IDS designs, and should display their icon/text properly (before removal of slot names, all the examples were displaying an "empty" but present button)

Angular: 

- http://localhost:4200/ids-button/example
- http://localhost:4200/ids-app-menu/example
- http://localhost:4200/ids-app-menu/example-footer
- http://localhost:4200/ids-app-menu/sandbox
- http://localhost:4200/ids-breadcrumb/toolbar
- http://localhost:4200/ids-card/footer
- http://localhost:4200/ids-checkbox/example
- http://localhost:4200/ids-empty-message/example
- http://localhost:4200/ids-expandable-area/example
- http://localhost:4200/ids-lookup/example
- http://localhost:4200/ids-masthead/example
- http://localhost:4200/ids-menu-button/example
- http://localhost:4200/ids-menu-button/disabled
- http://localhost:4200/ids-menu-button/display-selected
- http://localhost:4200/ids-modal/example
- http://localhost:4200/ids-modal/focus
- http://localhost:4200/ids-modal/fullsize
- http://localhost:4200/ids-modal/keep-open
- http://localhost:4200/ids-modal/nested
- http://localhost:4200/ids-modal/visible
- http://localhost:4200/ids-popup/example
- http://localhost:4200/ids-progress-bar/example
- http://localhost:4200/ids-radio/example
- http://localhost:4200/ids-search-field/example
- http://localhost:4200/ids-textarea/example
- http://localhost:4200/ids-toast/example
- http://localhost:4200/ids-toast/sandbox
- http://localhost:4200/ids-toggle-button/example
- http://localhost:4200/ids-toggle-button/icon-align-right
- http://localhost:4200/ids-toolbar/example
- http://localhost:4200/ids-toolbar/sandbox
- http://localhost:4200/ids-toolbar/overflowed
- http://localhost:4200/ids-tree/example
- http://localhost:4200/ids-upload-advanced/sandbox

The button examples in the React/Sveltekit example projects have also been updated, however I wasn't able to run them due to other build-related issues.
