### PR TITLE
904 - Fix to remove hash links for navigation with scroll view

### DIFF
--- a/angular-ids-wc/src/app/components/ids-scroll-view/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-scroll-view/demos/example/example.component.html
@@ -1,10 +1,10 @@
 <ids-container language="en" locale="en-US" padding="8" hidden>
   <ids-theme-switcher mode="light" version="new"></ids-theme-switcher>
   
-  <ids-layout-grid auto="true">
+  <ids-layout-grid auto-fit="true" padding="md">
     <ids-text font-size="12" type="h1">Scroll View</ids-text>
   </ids-layout-grid>
-  <ids-layout-grid cols="4">
+  <ids-layout-grid cols="1" cols-md="4" padding-x="md">
     <ids-layout-grid-cell col-span="1">
       <ids-scroll-view #scrollview>
         <img src='./assets/images/camera-1.png' class="camera-1" slot="scroll-view-item" alt="Slide 1, Sony Camera, Front"/>

--- a/angular-ids-wc/src/app/components/ids-scroll-view/ids-scroll-view.component.ts
+++ b/angular-ids-wc/src/app/components/ids-scroll-view/ids-scroll-view.component.ts
@@ -1,7 +1,5 @@
-import { Component, ElementRef, AfterViewInit, ViewChild } from '@angular/core';
-import { Router } from '@angular/router';
+import { Component, AfterViewInit } from '@angular/core';
 import { routes } from './ids-scroll-view-routing.module';
-import IdsDataGrid from 'ids-enterprise-wc/components/ids-data-grid/ids-data-grid';
 
 @Component({
   selector: 'app-ids-scroll-view',
@@ -9,16 +7,11 @@ import IdsDataGrid from 'ids-enterprise-wc/components/ids-data-grid/ids-data-gri
   styleUrls: ['./ids-scroll-view.component.css']
 })
 export class IdsScrollViewComponent implements AfterViewInit {
-  @ViewChild('table', { read: ElementRef }) table: IdsDataGrid;
   public routes = routes.filter(r => r.path !== '');
-  public columns = [];
 
-  constructor(
-    public router: Router
-  ) { }
+  constructor() { }
 
   ngAfterViewInit(): void {
     console.log('Ids Scroll View init');
   }
-
 }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Fixed to remove hash links for navigation with scroll view

**Related github/jira issue(s) (required)**:
Related infor-design/enterprise-wc#904

**Steps necessary to review your pull request (required)**:
- Pull, build and publish link WC branch ([904-scrollview-hash-links](https://github.com/infor-design/enterprise-wc/tree/904-scrollview-hash-links))
- `npm i && npm run start`
- `npm run publish:link` (in other tab)
- `npm run build:dist`
- Pull this branch and build/run the demo app (uUse `npm link`)
- `npm i`
- `npm link ids-enterprise-wc`
- `npm run start`
- Navigate to: http://localhost:4200/ids-scroll-view/example
- See url when move slides, does not use hash links
