### PR TITLE
1644 - Add data-driven/dynamic Angular examples for IdsRadio/IdsCheckbox

### DIFF
--- a/angular-ids-wc/src/app/components/demo-listing/demo-listing.component.html
+++ b/angular-ids-wc/src/app/components/demo-listing/demo-listing.component.html
@@ -1,11 +1,15 @@
 <ids-container language="en" locale="en-US" padding="8" hidden>
   <ids-theme-switcher mode="light"></ids-theme-switcher>
   
-  <ids-layout-grid cols="2" gap="md">
+  <ids-layout-grid auto-fit="true" padding="md">
     <ids-layout-grid-cell>
-      <ids-text font-size="20">{{title}}</ids-text>
+      <ids-text font-size="12" type="h1">{{title}}</ids-text>
     </ids-layout-grid-cell>
   </ids-layout-grid>
 
-  <ids-data-grid #table list-style="true"></ids-data-grid>
+  <ids-layout-grid auto-fit="true" padding-x="md">
+    <ids-layout-grid-cell>
+      <ids-data-grid #table list-style="true"></ids-data-grid>
+    </ids-layout-grid-cell>
+  </ids-layout-grid>
 </ids-container>

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/control-flow/control-flow.component.css
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/control-flow/control-flow.component.css
@@ -1,0 +1,3 @@
+code.pre {
+  white-space: pre;
+}

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/control-flow/control-flow.component.html
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/control-flow/control-flow.component.html
@@ -1,0 +1,62 @@
+<ids-container language="en" locale="en-US" padding="8" hidden>
+  <ids-theme-switcher mode="light"></ids-theme-switcher>
+  
+  <ids-layout-grid cols="4" gap="md" padding-x="md">
+    <ids-layout-grid-cell>
+      <ids-text font-size="12" type="h1">&#64;if and &#64;else</ids-text><br />
+      <ids-button
+        #displayCheckboxStatesBtnRef
+        appearance="secondary"
+        (click)="toggleCheckboxStatesDisplay()"
+        [attr.text]="this.displayCheckboxStates ? 'Hide Checkboxes' : 'Reveal Checkboxes'"></ids-button>
+      <br /><br />
+      @if (this.displayCheckboxStates === true) {
+        <ids-checkbox label="Unchecked"></ids-checkbox>
+        <ids-checkbox label="Checked" checked="true"></ids-checkbox>
+        <ids-checkbox label="Disabled and unchecked" disabled="true"></ids-checkbox>
+        <ids-checkbox label="Disabled and checked" checked="true" disabled="true"></ids-checkbox>
+        <ids-checkbox label="Required" validate="required"></ids-checkbox>
+        <ids-checkbox label="Not Animated" no-animation="true"></ids-checkbox>
+      }
+      @else {
+        <ids-text>Checkboxes are currently hidden</ids-text>
+      }
+    </ids-layout-grid-cell>
+
+    <ids-layout-grid-cell>
+      <ids-text font-size="12" type="h1">&#64;for</ids-text><br />
+      <ids-button 
+        #displayCheckboxOptionsBtnRef appearance="secondary" (click)="toggleCheckboxOptionsDisplay()"
+        text="Display Random Checkboxes"></ids-button>
+      <br /><br />
+      @for (option of checkboxOptions; let i = $index; track option.id) {
+        <ids-checkbox
+          name="name-{{i}}" 
+          label="{{option.text}}" 
+          checked="{{option.checked}}" 
+          disabled="{{option.disabled}}"
+          [ngModel]="checkboxOptions[i]"
+          (change)="onCheckboxChange($event, i)"></ids-checkbox>
+      }
+    </ids-layout-grid-cell>
+
+    <ids-layout-grid-cell>
+      <ids-text font-size="12" type="h1">*ngModel (models the &#64;for example)</ids-text><br />
+      <code class="pre">
+        @for (option of checkboxOptions; let i = $index, last = $last; track option.id) {
+          <div>
+            <span>{{'{'}}</span>
+            <span>text: "{{option.text}}", </span>
+            <span>checked: {{option.checked}}, </span>
+            <span>disabled: {{option.disabled}} </span>
+            <span>{{'}'}}</span>
+            @if (last) { <span>,</span> }
+          </div>
+        }
+        @empty {
+          <ids-text>No Checkboxes were rendered (dataset is empty)</ids-text>
+        }
+      </code>
+    </ids-layout-grid-cell>
+  </ids-layout-grid>
+</ids-container>

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/control-flow/control-flow.component.spec.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/control-flow/control-flow.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ControlFlowComponent } from './control-flow.component';
+
+describe('ControlFlowComponent', () => {
+  let component: ControlFlowComponent;
+  let fixture: ComponentFixture<ControlFlowComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ControlFlowComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ControlFlowComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/control-flow/control-flow.component.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/control-flow/control-flow.component.ts
@@ -1,0 +1,50 @@
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { randomInt, randomBool } from '../../../../../utils/random';
+
+function generateCheckboxDataItem() {
+  const id = randomInt(65536);
+  return {
+    id,
+    text: `Checkbox Option ${id}`,
+    checked: randomBool(),
+    disabled: randomBool()
+  }
+}
+
+@Component({
+  selector: 'app-example',
+  templateUrl: './control-flow.component.html',
+  styleUrls: ['./control-flow.component.css']
+})
+export class ControlFlowComponent implements OnInit {
+  @ViewChild('displayCheckboxStatesBtnRef', { read: ElementRef }) displayCheckboxStatesBtnRef;
+
+  displayCheckboxStates = false;
+  checkboxOptions = [];
+
+  constructor() { }
+
+  ngOnInit(): void {}
+
+  toggleCheckboxStatesDisplay() {
+    this.displayCheckboxStates = !this.displayCheckboxStates;
+  }
+
+  toggleCheckboxOptionsDisplay() {
+    let opts = [];
+    let numOptions = randomInt(50);
+    while (numOptions > 0) {
+      opts.push(generateCheckboxDataItem());
+      numOptions -= 1;
+    }
+    this.checkboxOptions = opts;
+  }
+
+  onCheckboxChange(event, i) {
+    const id = this.checkboxOptions[i].id;
+    const checked = event.target.checked;
+
+    this.checkboxOptions[i].checked = checked;
+    console.info(`Checkbox ${id} updated checked state to ${checked}`, this.checkboxOptions[i]);
+  }
+}

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/control-flow/control-flow.component.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/control-flow/control-flow.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { randomInt, randomBool } from '../../../../../utils/random';
 
 function generateCheckboxDataItem() {
@@ -16,15 +16,13 @@ function generateCheckboxDataItem() {
   templateUrl: './control-flow.component.html',
   styleUrls: ['./control-flow.component.css']
 })
-export class ControlFlowComponent implements OnInit {
+export class ControlFlowComponent {
   @ViewChild('displayCheckboxStatesBtnRef', { read: ElementRef }) displayCheckboxStatesBtnRef;
 
   displayCheckboxStates = false;
   checkboxOptions = [];
 
   constructor() { }
-
-  ngOnInit(): void {}
 
   toggleCheckboxStatesDisplay() {
     this.displayCheckboxStates = !this.displayCheckboxStates;

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.css
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.css
@@ -1,0 +1,3 @@
+code.pre {
+  white-space: pre;
+}

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.html
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.html
@@ -1,0 +1,54 @@
+<ids-container language="en" locale="en-US" padding="8" hidden>
+  <ids-theme-switcher mode="light"></ids-theme-switcher>
+  
+  <ids-layout-grid cols="4" gap="md" padding-x="md">
+    <ids-layout-grid-cell>
+      <ids-text font-size="12" type="h1">*ngIf</ids-text><br />
+      <ids-button
+        #displayCheckboxStatesBtnRef
+        appearance="secondary"
+        (click)="toggleCheckboxStatesDisplay()"
+        [attr.text]="this.displayCheckboxStates ? 'Hide Checkboxes' : 'Reveal Checkboxes'"></ids-button>
+      <br /><br />
+      <div *ngIf="this.displayCheckboxStates === true">
+        <ids-checkbox label="Unchecked"></ids-checkbox>
+        <ids-checkbox label="Checked" checked="true"></ids-checkbox>
+        <ids-checkbox label="Disabled and unchecked" disabled="true"></ids-checkbox>
+        <ids-checkbox label="Disabled and checked" checked="true" disabled="true"></ids-checkbox>
+        <ids-checkbox label="Required" validate="required"></ids-checkbox>
+        <ids-checkbox label="Not Animated" no-animation="true"></ids-checkbox>
+      </div>
+    </ids-layout-grid-cell>
+
+    <ids-layout-grid-cell>
+      <ids-text font-size="12" type="h1">*ngFor</ids-text><br />
+      <ids-button 
+        #displayCheckboxOptionsBtnRef appearance="secondary" (click)="toggleCheckboxOptionsDisplay()"
+        text="Display Random Checkboxes"></ids-button>
+      <br /><br />
+      <div 
+        *ngFor="let option of checkboxOptions; index as i">
+        <ids-checkbox
+          name="name-{{i}}" 
+          label="{{option.text}}" 
+          checked="{{option.checked}}" 
+          disabled="{{option.disabled}}"
+          [(ngModel)]="checkboxOptions[i]"
+          (change)="onCheckboxChange($event, i)"></ids-checkbox>
+      </div>
+    </ids-layout-grid-cell>
+
+    <ids-layout-grid-cell>
+      <ids-text font-size="12" type="h1">*ngModel (models the *ngFor example)</ids-text><br />
+      <code class="pre" *ngFor="let option of checkboxOptions; index as i; last as isLast">
+        <div>
+          <span>{{'{'}}</span>
+          <span>text: "{{option.text}}", </span>
+          <span>checked: {{option.checked}}, </span>
+          <span>disabled: {{option.disabled}} </span>
+          <span>{{'}'}}</span><span *ngIf="!isLast">,</span>
+        </div>
+      </code>
+    </ids-layout-grid-cell>
+  </ids-layout-grid>
+</ids-container>

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.html
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.html
@@ -26,16 +26,14 @@
         #displayCheckboxOptionsBtnRef appearance="secondary" (click)="toggleCheckboxOptionsDisplay()"
         text="Display Random Checkboxes"></ids-button>
       <br /><br />
-      <div 
-        *ngFor="let option of checkboxOptions; index as i">
         <ids-checkbox
+          *ngFor="let option of checkboxOptions; index as i"
           name="name-{{i}}" 
           label="{{option.text}}" 
           checked="{{option.checked}}" 
           disabled="{{option.disabled}}"
           [(ngModel)]="checkboxOptions[i]"
           (change)="onCheckboxChange($event, i)"></ids-checkbox>
-      </div>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.html
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.html
@@ -10,7 +10,7 @@
         (click)="toggleCheckboxStatesDisplay()"
         [attr.text]="this.displayCheckboxStates ? 'Hide Checkboxes' : 'Reveal Checkboxes'"></ids-button>
       <br /><br />
-      <div *ngIf="this.displayCheckboxStates === true">
+      <div *ngIf="this.displayCheckboxStates === true; else displayCheckboxElseBlock">
         <ids-checkbox label="Unchecked"></ids-checkbox>
         <ids-checkbox label="Checked" checked="true"></ids-checkbox>
         <ids-checkbox label="Disabled and unchecked" disabled="true"></ids-checkbox>
@@ -18,12 +18,17 @@
         <ids-checkbox label="Required" validate="required"></ids-checkbox>
         <ids-checkbox label="Not Animated" no-animation="true"></ids-checkbox>
       </div>
+      <ng-template #displayCheckboxElseBlock>
+        <ids-text>Checkboxes are currently hidden</ids-text>
+      </ng-template>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
       <ids-text font-size="12" type="h1">*ngFor</ids-text><br />
       <ids-button 
-        #displayCheckboxOptionsBtnRef appearance="secondary" (click)="toggleCheckboxOptionsDisplay()"
+        #displayCheckboxOptionsBtnRef 
+        appearance="secondary" 
+        (click)="toggleCheckboxOptionsDisplay()"
         text="Display Random Checkboxes"></ids-button>
       <br /><br />
         <ids-checkbox
@@ -47,6 +52,7 @@
           <span>{{'}'}}</span><span *ngIf="!isLast">,</span>
         </div>
       </code>
+      <ids-text *ngIf="!checkboxOptions.length">No Checkboxes were rendered (dataset is empty)</ids-text>
     </ids-layout-grid-cell>
   </ids-layout-grid>
 </ids-container>

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.spec.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DataDrivenComponent } from './data-driven.component';
+
+describe('DataDrivenComponent', () => {
+  let component: DataDrivenComponent;
+  let fixture: ComponentFixture<DataDrivenComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DataDrivenComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DataDrivenComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.ts
@@ -1,0 +1,57 @@
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+
+function randomInt(max: number) { 
+  return Math.floor(Math.random() * max) 
+};
+
+function randomBool() {
+  return Math.random() < 0.5;
+}
+
+function generateCheckboxDataItem() {
+  const id = randomInt(65536);
+  return {
+    id,
+    text: `Checkbox Option ${id}`,
+    checked: randomBool(),
+    disabled: randomBool()
+  }
+}
+
+@Component({
+  selector: 'app-example',
+  templateUrl: './data-driven.component.html',
+  styleUrls: ['./data-driven.component.css']
+})
+export class DataDrivenComponent implements OnInit {
+  @ViewChild('displayCheckboxStatesBtnRef', { read: ElementRef }) displayCheckboxStatesBtnRef;
+
+  displayCheckboxStates = false;
+  checkboxOptions = [];
+
+  constructor() { }
+
+  ngOnInit(): void {}
+
+  toggleCheckboxStatesDisplay() {
+    this.displayCheckboxStates = !this.displayCheckboxStates;
+  }
+
+  toggleCheckboxOptionsDisplay() {
+    let opts = [];
+    let numOptions = randomInt(50);
+    while (numOptions > 0) {
+      opts.push(generateCheckboxDataItem());
+      numOptions -= 1;
+    }
+    this.checkboxOptions = opts;
+  }
+
+  onCheckboxChange(event, i) {
+    const id = this.checkboxOptions[i].id;
+    const checked = event.target.checked;
+
+    this.checkboxOptions[i].checked = checked;
+    console.info(`Checkbox ${id} updated checked state to ${checked}`, this.checkboxOptions[i]);
+  }
+}

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.ts
@@ -1,12 +1,5 @@
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
-
-function randomInt(max: number) { 
-  return Math.floor(Math.random() * max) 
-};
-
-function randomBool() {
-  return Math.random() < 0.5;
-}
+import { randomInt, randomBool } from '../../../../../utils/random';
 
 function generateCheckboxDataItem() {
   const id = randomInt(65536);

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/data-driven/data-driven.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { randomInt, randomBool } from '../../../../../utils/random';
 
 function generateCheckboxDataItem() {
@@ -16,15 +16,13 @@ function generateCheckboxDataItem() {
   templateUrl: './data-driven.component.html',
   styleUrls: ['./data-driven.component.css']
 })
-export class DataDrivenComponent implements OnInit {
+export class DataDrivenComponent {
   @ViewChild('displayCheckboxStatesBtnRef', { read: ElementRef }) displayCheckboxStatesBtnRef;
 
   displayCheckboxStates = false;
   checkboxOptions = [];
 
   constructor() { }
-
-  ngOnInit(): void {}
 
   toggleCheckboxStatesDisplay() {
     this.displayCheckboxStates = !this.displayCheckboxStates;

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/deferred/deferred.component.css
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/deferred/deferred.component.css
@@ -1,0 +1,3 @@
+code.pre {
+  white-space: pre;
+}

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/deferred/deferred.component.html
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/deferred/deferred.component.html
@@ -1,0 +1,31 @@
+<ids-container language="en" locale="en-US" padding="8" hidden>
+  <ids-theme-switcher mode="light"></ids-theme-switcher>
+  
+  <ids-layout-grid cols="4" gap="md" padding-x="md">
+    <ids-layout-grid-cell>
+      <ids-text font-size="12" type="h1">&#64;deferred IdsCheckbox</ids-text><br />
+      <ids-button
+        #displayCheckboxBtnRef
+        appearance="secondary"
+        (click)="isCheckedDeferred.set(true)"
+        text="Load Deferred Content"
+        [attr.disabled]="isCheckedDeferred()"></ids-button>
+      <br /><br />
+      @defer (when isCheckedDeferred()) {
+        <ids-checkbox 
+          #deferredCheckboxRef
+          label="Deferred Checkbox"
+          (change)="onCheckboxChange($event)"></ids-checkbox>
+      }
+      @placeholder {
+        <ids-text>No Checkbox has been loaded yet...</ids-text>
+      }
+      @error {
+        <ids-text>There was an error loading the checkbox...</ids-text>
+      }
+      @loading(minimum 1s) {
+        <ids-loading-indicator></ids-loading-indicator>
+      }
+    </ids-layout-grid-cell>
+  </ids-layout-grid>
+</ids-container>

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/deferred/deferred.component.spec.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/deferred/deferred.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeferredComponent } from './deferred.component';
+
+describe('DeferredComponent', () => {
+  let component: DeferredComponent;
+  let fixture: ComponentFixture<DeferredComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DeferredComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DeferredComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/deferred/deferred.component.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/deferred/deferred.component.ts
@@ -1,0 +1,20 @@
+import { Component, ElementRef, ViewChild, signal } from '@angular/core';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: './deferred.component.html',
+  styleUrls: ['./deferred.component.css']
+})
+export class DeferredComponent {
+  @ViewChild('displayCheckboxBtnRef', { read: ElementRef }) displayCheckboxBtnRef;
+  @ViewChild('deferredCheckboxRef', { read: ElementRef }) deferredCheckboxRef;
+
+  isCheckedDeferred = signal(false);
+
+  constructor() { }
+
+  onCheckboxChange(event) {
+    const checked = event.target.checked;
+    console.info(`Checkbox updated checked state to ${checked}`);
+  }
+}

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/example/example.component.html
@@ -1,51 +1,57 @@
 <ids-container language="en" locale="en-US" padding="8" hidden>
   <ids-theme-switcher mode="light"></ids-theme-switcher>
   
-  <ids-layout-grid cols="3" gap="md">
+  <ids-layout-grid cols="4" gap="md" padding-x="md">
     <ids-layout-grid-cell>
-      <ids-text font-size="12" type="h1">Ids Checkbox</ids-text><br />
+      <ids-text font-size="12" type="h1">Checkbox States</ids-text><br />
       <ids-checkbox label="Unchecked"></ids-checkbox>
-      <ids-checkbox label="Checked" [attr.checked]="true"></ids-checkbox>
-      <ids-checkbox label="Dirty tracking" dirty-tracker="true"></ids-checkbox>
-      <ids-checkbox label="Disabled and unchecked" [attr.disabled]="true"></ids-checkbox>
-      <ids-checkbox label="Disabled and checked"[attr.checked]="true" [attr.disabled]="true"></ids-checkbox>
+      <ids-checkbox label="Checked" checked="true"></ids-checkbox>
+      <ids-checkbox label="Disabled and unchecked" disabled="true"></ids-checkbox>
+      <ids-checkbox label="Disabled and checked" checked="true" disabled="true"></ids-checkbox>
       <ids-checkbox label="Required" validate="required"></ids-checkbox>
+      <ids-checkbox label="Not Animated" no-animation="true"></ids-checkbox>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
-      <ids-text font-size="12" type="h1">Ids Checkbox with no label</ids-text><br />
-      <ids-checkbox label="UnChecked" label-audible="true"></ids-checkbox>
-      <ids-checkbox label="Checked" checked="true" label-audible="false"></ids-checkbox>
+      <ids-text font-size="12" type="h1">Checkbox with no label</ids-text><br />
+      <ids-checkbox label="UnChecked" label-audible="true" label-state="hidden"></ids-checkbox>
+      <ids-checkbox label="Checked" checked="true" label-audible="false" label-state="hidden"></ids-checkbox>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
-      <ids-text font-size="12" type="h1">Ids Checkbox - Colored</ids-text><br />
-      <ids-checkbox checked="true" color="emerald07" label="Emerald 07"></ids-checkbox>
-      <ids-checkbox checked="true" color="amethyst07" label="Amethyst 07"></ids-checkbox>
-      <ids-checkbox checked="true" color="azure07" label="Azure 07"></ids-checkbox>
-      <ids-checkbox checked="true" color="amber07" label="Amber 07"></ids-checkbox>
-      <ids-checkbox checked="true" color="ruby07" label="Ruby 07"></ids-checkbox>
-      <ids-checkbox checked="true" color="ruby07" label="Ruby 07 (disabled)" disabled="true"></ids-checkbox>
+      <ids-text font-size="12" type="h1">Colored Checkbox</ids-text><br />
+      <ids-checkbox checked="true" color="emerald" label="Emerald"></ids-checkbox>
+      <ids-checkbox checked="true" color="amethyst" label="Amethyst"></ids-checkbox>
+      <ids-checkbox checked="true" color="azure" label="Azure"></ids-checkbox>
+      <ids-checkbox checked="true" color="amber" label="Amber"></ids-checkbox>
+      <ids-checkbox checked="true" color="ruby" label="Ruby"></ids-checkbox>
+      <ids-checkbox checked="true" color="ruby" label="Ruby (disabled)" disabled="true"></ids-checkbox>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
-      <ids-text font-size="12" type="h1">Ids Indeterminate</ids-text><br />
-      <ids-checkbox label="Indeterminate" indeterminate="true" id="cb-indeterminate"></ids-checkbox>
-      <ids-button appearance="secondary" id="btn-set-indeterminate">
+      <ids-text font-size="12" type="h1">Indeterminate Checkbox</ids-text><br />
+      <ids-checkbox 
+        #indeterminateCheckboxRef 
+        label="Indeterminate" 
+        indeterminate="true" 
+        id="cb-indeterminate"></ids-checkbox>
+      <ids-button appearance="secondary" id="btn-set-indeterminate" (click)="setIndeterminate()">
         <span>Set</span>
       </ids-button>
-      <ids-button appearance="secondary" id="btn-remove-indeterminate">
+      &nbsp;
+      <ids-button appearance="secondary" id="btn-remove-indeterminate" (click)="removeIndeterminate()">
         <span>Remove</span>
       </ids-button>
 
       <br /><br />
-      <ids-text font-size="12" type="h1">Ids Checkbox - Horizontal</ids-text><br />
+      <ids-text font-size="12" type="h1">Horizontal Checkbox</ids-text><br />
 
       <ids-checkbox label="Option 1 I am long" horizontal="true"></ids-checkbox>
       <ids-checkbox label="Option 2" horizontal="true" checked="true"></ids-checkbox>
       <ids-checkbox label="Option 3" horizontal="true" checked="true"></ids-checkbox>
     </ids-layout-grid-cell>
 
+    <!--
     <ids-layout-grid-cell>
       <ids-text font-size="12" type="h1">Ids Checkbox with Hitbox</ids-text><br />
       <ids-checkbox label="Unchecked" hitbox="true"></ids-checkbox>
@@ -58,5 +64,6 @@
       <ids-checkbox label="Disabled and checked" checked="true" disabled="true" hitbox="true"></ids-checkbox>
       <ids-checkbox label="Required" validate="required" hitbox="true"></ids-checkbox>
     </ids-layout-grid-cell>
+    -->
   </ids-layout-grid>
 </ids-container>

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/example/example.component.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/example/example.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 
 @Component({
   selector: 'app-example',
@@ -6,10 +6,20 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./example.component.css']
 })
 export class ExampleComponent implements OnInit {
+  @ViewChild('indeterminateCheckboxRef', { read: ElementRef }) indeterminateCheckboxRef;
 
   constructor() { }
 
   ngOnInit(): void {
+
+  }
+
+  setIndeterminate() {
+    this.indeterminateCheckboxRef.nativeElement.indeterminate = true;
+  }
+
+  removeIndeterminate() {
+    this.indeterminateCheckboxRef.nativeElement.indeterminate = false;
   }
 
 }

--- a/angular-ids-wc/src/app/components/ids-checkbox/demos/example/example.component.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/demos/example/example.component.ts
@@ -1,18 +1,14 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 
 @Component({
   selector: 'app-example',
   templateUrl: './example.component.html',
   styleUrls: ['./example.component.css']
 })
-export class ExampleComponent implements OnInit {
+export class ExampleComponent {
   @ViewChild('indeterminateCheckboxRef', { read: ElementRef }) indeterminateCheckboxRef;
 
   constructor() { }
-
-  ngOnInit(): void {
-
-  }
 
   setIndeterminate() {
     this.indeterminateCheckboxRef.nativeElement.indeterminate = true;
@@ -21,5 +17,4 @@ export class ExampleComponent implements OnInit {
   removeIndeterminate() {
     this.indeterminateCheckboxRef.nativeElement.indeterminate = false;
   }
-
 }

--- a/angular-ids-wc/src/app/components/ids-checkbox/ids-checkbox-routing.module.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/ids-checkbox-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { IdsCheckboxComponent } from './ids-checkbox.component';
 import { ExampleComponent } from './demos/example/example.component';
+import { ControlFlowComponent } from './demos/control-flow/control-flow.component';
 import { DataDrivenComponent } from './demos/data-driven/data-driven.component';
 
 export const routes: Routes = [
@@ -13,6 +14,10 @@ export const routes: Routes = [
   {
     path: 'example',
     component: ExampleComponent
+  },
+  {
+    path: 'control-flow',
+    component: ControlFlowComponent
   },
   {
     path: 'data-driven',

--- a/angular-ids-wc/src/app/components/ids-checkbox/ids-checkbox-routing.module.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/ids-checkbox-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { IdsCheckboxComponent } from './ids-checkbox.component';
 import { ExampleComponent } from './demos/example/example.component';
+import { DataDrivenComponent } from './demos/data-driven/data-driven.component';
 
 export const routes: Routes = [
   { 
@@ -12,6 +13,10 @@ export const routes: Routes = [
   {
     path: 'example',
     component: ExampleComponent
+  },
+  {
+    path: 'data-driven',
+    component: DataDrivenComponent
   }
 ];
 

--- a/angular-ids-wc/src/app/components/ids-checkbox/ids-checkbox-routing.module.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/ids-checkbox-routing.module.ts
@@ -5,6 +5,7 @@ import { IdsCheckboxComponent } from './ids-checkbox.component';
 import { ExampleComponent } from './demos/example/example.component';
 import { ControlFlowComponent } from './demos/control-flow/control-flow.component';
 import { DataDrivenComponent } from './demos/data-driven/data-driven.component';
+import { DeferredComponent } from './demos/deferred/deferred.component';
 
 export const routes: Routes = [
   { 
@@ -22,7 +23,11 @@ export const routes: Routes = [
   {
     path: 'data-driven',
     component: DataDrivenComponent
-  }
+  },
+  {
+    path: 'deferred',
+    component: DeferredComponent
+  },
 ];
 
 @NgModule({

--- a/angular-ids-wc/src/app/components/ids-checkbox/ids-checkbox.module.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/ids-checkbox.module.ts
@@ -4,13 +4,15 @@ import { CommonModule } from '@angular/common';
 import { IdsCheckboxRoutingModule } from './ids-checkbox-routing.module';
 import { IdsCheckboxComponent } from './ids-checkbox.component';
 import { ExampleComponent } from './demos/example/example.component';
+import { DataDrivenComponent } from './demos/data-driven/data-driven.component';
 import { DemoListingModule } from '../demo-listing/demo-listing.module';
 
 
 @NgModule({
   declarations: [
     IdsCheckboxComponent,
-    ExampleComponent
+    ExampleComponent,
+    DataDrivenComponent
   ],
   imports: [
     CommonModule,

--- a/angular-ids-wc/src/app/components/ids-checkbox/ids-checkbox.module.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/ids-checkbox.module.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import { IdsCheckboxRoutingModule } from './ids-checkbox-routing.module';
 import { IdsCheckboxComponent } from './ids-checkbox.component';
 import { ExampleComponent } from './demos/example/example.component';
+import { ControlFlowComponent } from './demos/control-flow/control-flow.component';
 import { DataDrivenComponent } from './demos/data-driven/data-driven.component';
 import { DemoListingModule } from '../demo-listing/demo-listing.module';
 
@@ -12,6 +13,7 @@ import { DemoListingModule } from '../demo-listing/demo-listing.module';
   declarations: [
     IdsCheckboxComponent,
     ExampleComponent,
+    ControlFlowComponent,
     DataDrivenComponent
   ],
   imports: [

--- a/angular-ids-wc/src/app/components/ids-checkbox/ids-checkbox.module.ts
+++ b/angular-ids-wc/src/app/components/ids-checkbox/ids-checkbox.module.ts
@@ -6,6 +6,7 @@ import { IdsCheckboxComponent } from './ids-checkbox.component';
 import { ExampleComponent } from './demos/example/example.component';
 import { ControlFlowComponent } from './demos/control-flow/control-flow.component';
 import { DataDrivenComponent } from './demos/data-driven/data-driven.component';
+import { DeferredComponent } from './demos/deferred/deferred.component';
 import { DemoListingModule } from '../demo-listing/demo-listing.module';
 
 
@@ -14,7 +15,8 @@ import { DemoListingModule } from '../demo-listing/demo-listing.module';
     IdsCheckboxComponent,
     ExampleComponent,
     ControlFlowComponent,
-    DataDrivenComponent
+    DataDrivenComponent,
+    DeferredComponent
   ],
   imports: [
     CommonModule,

--- a/angular-ids-wc/src/app/components/ids-radio/demos/control-flow/control-flow.component.css
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/control-flow/control-flow.component.css
@@ -1,0 +1,3 @@
+code.pre {
+  white-space: pre;
+}

--- a/angular-ids-wc/src/app/components/ids-radio/demos/control-flow/control-flow.component.html
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/control-flow/control-flow.component.html
@@ -1,0 +1,75 @@
+<ids-container language="en" locale="en-US" padding="8" hidden>
+  <ids-theme-switcher mode="light"></ids-theme-switcher>
+
+  <ids-layout-grid cols="4" gap="md" padding-x="md">
+    <ids-layout-grid-cell>
+      <ids-text font-size="12" type="h1">&#64;if and &#64;else</ids-text><br />
+      <ids-button
+      #radioGroupDisplayBtnRef
+      appearance="secondary"
+      (click)="toggleRadioGroupDisplay()"
+      [attr.text]="radioGroupDisplay ? 'Hide Radio Groups' : 'Show Radio Groups'"></ids-button>
+      <br /><br />
+      @if (radioGroupDisplay === true) {
+        <ids-radio-group label="Normal">
+          <ids-radio value="opt1" label="Option one"></ids-radio>
+          <ids-radio value="opt2" label="Option two" checked="true"></ids-radio>
+        </ids-radio-group>
+
+        <ids-radio-group label="Disabled Group" disabled="true">
+          <ids-radio value="opt1" label="Option one" checked="true"></ids-radio>
+          <ids-radio value="opt2" label="Option two"></ids-radio>
+        </ids-radio-group>
+
+        <ids-radio-group label="Disabled Item">
+          <ids-radio value="opt1" label="Option one"></ids-radio>
+          <ids-radio value="opt2" label="Option two" checked="true"></ids-radio>
+          <ids-radio value="opt3" label="Option three" disabled="true"></ids-radio>
+        </ids-radio-group>
+      }
+      @else {
+        <ids-text>Radio Groups are currently hidden</ids-text>
+      }
+    </ids-layout-grid-cell>
+
+    <ids-layout-grid-cell>
+      <ids-text font-size="12" type="h1">&#64;for</ids-text><br />
+      <ids-button 
+        #displayRadioItemsBtnRef 
+        appearance="secondary" 
+        (click)="generateRadioItems()"
+        text="Display Random Radios"></ids-button>
+      <br /><br />
+      <ids-radio-group>
+        @for (option of radioItems; let i = $index; track option.id) {
+        <ids-radio
+          name="name-{{i}}" 
+          label="{{option.text}}" 
+          checked="{{option.checked}}" 
+          disabled="{{option.disabled}}"
+          [ngModel]="radioItems" 
+          (change)="onRadioChange($event, i)"></ids-radio>
+        }
+      </ids-radio-group>
+    </ids-layout-grid-cell>
+
+    <ids-layout-grid-cell col-span="2">
+      <ids-text font-size="12" type="h1">*ngModel (models the &#64;for example)</ids-text><br />
+      <code class="pre">
+        @for (option of radioItems; let i = $index, last = $last; track option.id) {
+          <div id="line-{{i}}">
+            <span>{{'{'}}</span>
+            <span>text: "{{option.text}}", </span>
+            <span>checked: {{option.checked}}, </span>
+            <span>disabled: {{option.disabled}} </span>
+            <span>{{'}'}}</span>
+            @if (last) { <span>,</span> }
+          </div>
+        }
+        @empty {
+          <ids-text>No Radios were rendered (dataset is empty)</ids-text>
+        }
+      </code>
+    </ids-layout-grid-cell>
+  </ids-layout-grid>
+</ids-container>

--- a/angular-ids-wc/src/app/components/ids-radio/demos/control-flow/control-flow.component.spec.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/control-flow/control-flow.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ControlFlowComponent } from './control-flow.component';
+
+describe('ControlFlowComponent', () => {
+  let component: ControlFlowComponent;
+  let fixture: ComponentFixture<ControlFlowComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ControlFlowComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ControlFlowComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-ids-wc/src/app/components/ids-radio/demos/control-flow/control-flow.component.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/control-flow/control-flow.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { randomInt, randomBool } from '../../../../../utils/random';
 
 function generateRadioDataItem(noTrue: boolean) {
@@ -15,17 +15,13 @@ function generateRadioDataItem(noTrue: boolean) {
   templateUrl: './control-flow.component.html',
   styleUrls: ['./control-flow.component.css']
 })
-export class ControlFlowComponent implements OnInit {
+export class ControlFlowComponent {
   @ViewChild('displayRadioItemsBtnRef', { read: ElementRef }) displayRadioItemsBtnRef;
 
   constructor() { }
 
   radioGroupDisplay = false;
   radioItems = [];
-
-  ngOnInit(): void {
-
-  }
 
   toggleRadioGroupDisplay() {
     this.radioGroupDisplay = !this.radioGroupDisplay;

--- a/angular-ids-wc/src/app/components/ids-radio/demos/control-flow/control-flow.component.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/control-flow/control-flow.component.ts
@@ -1,0 +1,56 @@
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { randomInt, randomBool } from '../../../../../utils/random';
+
+function generateRadioDataItem(noTrue: boolean) {
+  const id = randomInt(65536);
+  return {
+    id,
+    text: `Radio ${id}`,
+    checked: noTrue ? false : randomBool(),
+    disabled: randomBool()
+  }
+}
+@Component({
+  selector: 'app-example',
+  templateUrl: './control-flow.component.html',
+  styleUrls: ['./control-flow.component.css']
+})
+export class ControlFlowComponent implements OnInit {
+  @ViewChild('displayRadioItemsBtnRef', { read: ElementRef }) displayRadioItemsBtnRef;
+
+  constructor() { }
+
+  radioGroupDisplay = false;
+  radioItems = [];
+
+  ngOnInit(): void {
+
+  }
+
+  toggleRadioGroupDisplay() {
+    this.radioGroupDisplay = !this.radioGroupDisplay;
+  }
+
+  generateRadioItems() {
+    let opts = [];
+    let numOptions = randomInt(50);
+    let hasTrueVal = false;
+    while (numOptions > 0) {
+      let item = generateRadioDataItem(hasTrueVal);
+      if (item.checked) hasTrueVal = true;
+      opts.push(item);
+      numOptions -= 1;
+    }
+    this.radioItems = opts;
+  }
+
+  onRadioChange(event, i) {
+    const id = this.radioItems[i].id;
+    const checked = event.target.checked;
+
+    this.radioItems.forEach((item, j) => {
+      item.checked = i === j;
+    });
+    console.info(`Radio ${id} updated checked state to ${checked}`, this.radioItems[i]);
+  }
+}

--- a/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.css
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.css
@@ -1,0 +1,3 @@
+code.pre {
+  white-space: pre;
+}

--- a/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.html
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.html
@@ -44,12 +44,12 @@
           label="{{option.text}}" 
           checked="{{option.checked}}" 
           disabled="{{option.disabled}}"
-          [(ngModel)]="radioItems" 
+          [ngModel]="radioItems" 
           (change)="onRadioChange($event, i)"></ids-radio>
       </ids-radio-group>
     </ids-layout-grid-cell>
 
-    <ids-layout-grid-cell>
+    <ids-layout-grid-cell col-span="2">
       <ids-text font-size="12" type="h1">*ngModel (models the *ngFor example)</ids-text><br />
       <code class="pre" *ngFor="let option of radioItems; index as i; last as isLast">
         <div id="line-{{i}}">

--- a/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.html
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.html
@@ -10,7 +10,7 @@
       (click)="toggleRadioGroupDisplay()"
       [attr.text]="radioGroupDisplay ? 'Hide Radio Groups' : 'Show Radio Groups'"></ids-button>
       <br /><br />
-      <div *ngIf="radioGroupDisplay === true">
+      <div *ngIf="radioGroupDisplay === true; else radioGroupElseBlock">
         <ids-radio-group label="Normal">
           <ids-radio value="opt1" label="Option one"></ids-radio>
           <ids-radio value="opt2" label="Option two" checked="true"></ids-radio>
@@ -27,6 +27,9 @@
           <ids-radio value="opt3" label="Option three" disabled="true"></ids-radio>
         </ids-radio-group>
       </div>
+      <ng-template #radioGroupElseBlock>
+        <ids-text>Radio Groups are currently hidden</ids-text>
+      </ng-template>
     </ids-layout-grid-cell>
 
     <ids-layout-grid-cell>
@@ -60,6 +63,7 @@
           <span>{{'}'}}</span><span *ngIf="!isLast">,</span>
         </div>
       </code>
+      <ids-text *ngIf="!radioItems.length">No Radios were rendered (dataset is empty)</ids-text>
     </ids-layout-grid-cell>
   </ids-layout-grid>
 </ids-container>

--- a/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.html
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.html
@@ -1,0 +1,65 @@
+<ids-container language="en" locale="en-US" padding="8" hidden>
+  <ids-theme-switcher mode="light"></ids-theme-switcher>
+
+  <ids-layout-grid cols="4" gap="md" padding-x="md">
+    <ids-layout-grid-cell>
+      <ids-text font-size="12" type="h1">*ngIf</ids-text><br />
+      <ids-button
+      #radioGroupDisplayBtnRef
+      appearance="secondary"
+      (click)="toggleRadioGroupDisplay()"
+      [attr.text]="radioGroupDisplay ? 'Hide Radio Groups' : 'Show Radio Groups'"></ids-button>
+      <br /><br />
+      <div *ngIf="radioGroupDisplay === true">
+        <ids-radio-group label="Normal">
+          <ids-radio value="opt1" label="Option one"></ids-radio>
+          <ids-radio value="opt2" label="Option two" checked="true"></ids-radio>
+        </ids-radio-group>
+
+        <ids-radio-group label="Disabled Group" disabled="true">
+          <ids-radio value="opt1" label="Option one" checked="true"></ids-radio>
+          <ids-radio value="opt2" label="Option two"></ids-radio>
+        </ids-radio-group>
+
+        <ids-radio-group label="Disabled Item">
+          <ids-radio value="opt1" label="Option one"></ids-radio>
+          <ids-radio value="opt2" label="Option two" checked="true"></ids-radio>
+          <ids-radio value="opt3" label="Option three" disabled="true"></ids-radio>
+        </ids-radio-group>
+      </div>
+    </ids-layout-grid-cell>
+
+    <ids-layout-grid-cell>
+      <ids-text font-size="12" type="h1">*ngFor</ids-text><br />
+      <ids-button 
+        #displayRadioItemsBtnRef 
+        appearance="secondary" 
+        (click)="generateRadioItems()"
+        text="Display Random Radios"></ids-button>
+      <br /><br />
+      <ids-radio-group>
+        <ids-radio 
+          *ngFor="let option of radioItems; index as i"
+          name="name-{{i}}" 
+          label="{{option.text}}" 
+          checked="{{option.checked}}" 
+          disabled="{{option.disabled}}"
+          [(ngModel)]="radioItems" 
+          (change)="onRadioChange($event, i)"></ids-radio>
+      </ids-radio-group>
+    </ids-layout-grid-cell>
+
+    <ids-layout-grid-cell>
+      <ids-text font-size="12" type="h1">*ngModel (models the *ngFor example)</ids-text><br />
+      <code class="pre" *ngFor="let option of radioItems; index as i; last as isLast">
+        <div id="line-{{i}}">
+          <span>{{'{'}}</span>
+          <span>text: "{{option.text}}", </span>
+          <span>checked: {{option.checked}}, </span>
+          <span>disabled: {{option.disabled}} </span>
+          <span>{{'}'}}</span><span *ngIf="!isLast">,</span>
+        </div>
+      </code>
+    </ids-layout-grid-cell>
+  </ids-layout-grid>
+</ids-container>

--- a/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.spec.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DataDrivenComponent } from './data-driven.component';
+
+describe('DataDrivenComponent', () => {
+  let component: DataDrivenComponent;
+  let fixture: ComponentFixture<DataDrivenComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DataDrivenComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DataDrivenComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.ts
@@ -1,0 +1,65 @@
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { randomInt, randomBool } from '../../../../../utils/random';
+
+function generateRadioDataItem(noTrue: boolean) {
+  const id = randomInt(65536);
+  return {
+    id,
+    text: `Radio ${id}`,
+    checked: noTrue ? false : randomBool(),
+    disabled: randomBool()
+  }
+}
+@Component({
+  selector: 'app-example',
+  templateUrl: './data-driven.component.html',
+  styleUrls: ['./data-driven.component.css']
+})
+export class DataDrivenComponent implements OnInit {
+  @ViewChild('validatedRadioGroupRef', { read: ElementRef }) validatedRadioGroupRef;
+  @ViewChild('displayRadioItemsBtnRef', { read: ElementRef }) displayRadioItemsBtnRef;
+
+  constructor() { }
+
+  radioGroupDisplay = false;
+  radioItems = [];
+
+  ngOnInit(): void {
+
+  }
+
+  toggleRadioGroupDisplay() {
+    this.radioGroupDisplay = !this.radioGroupDisplay;
+  }
+
+  validateRadioGroup() {
+    this.validatedRadioGroupRef.nativeElement.checkValidation();
+  }
+
+  clearRadioGroupValidation() {
+    this.validatedRadioGroupRef.nativeElement.clear();
+  }
+
+  generateRadioItems() {
+    let opts = [];
+    let numOptions = randomInt(50);
+    let hasTrueVal = false;
+    while (numOptions > 0) {
+      let item = generateRadioDataItem(hasTrueVal);
+      if (item.checked) hasTrueVal = true;
+      opts.push(item);
+      numOptions -= 1;
+    }
+    this.radioItems = opts;
+  }
+
+  onRadioChange(event, i) {
+    const id = this.radioItems[i].id;
+    const checked = event.target.checked;
+
+    this.radioItems.forEach((item, j) => {
+      item.checked = i === j;
+    });
+    console.info(`Radio ${id} updated checked state to ${checked}`, this.radioItems[i]);
+  }
+}

--- a/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { randomInt, randomBool } from '../../../../../utils/random';
 
 function generateRadioDataItem(noTrue: boolean) {
@@ -15,17 +15,13 @@ function generateRadioDataItem(noTrue: boolean) {
   templateUrl: './data-driven.component.html',
   styleUrls: ['./data-driven.component.css']
 })
-export class DataDrivenComponent implements OnInit {
+export class DataDrivenComponent {
   @ViewChild('displayRadioItemsBtnRef', { read: ElementRef }) displayRadioItemsBtnRef;
 
   constructor() { }
 
   radioGroupDisplay = false;
   radioItems = [];
-
-  ngOnInit(): void {
-
-  }
 
   toggleRadioGroupDisplay() {
     this.radioGroupDisplay = !this.radioGroupDisplay;

--- a/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/data-driven/data-driven.component.ts
@@ -16,7 +16,6 @@ function generateRadioDataItem(noTrue: boolean) {
   styleUrls: ['./data-driven.component.css']
 })
 export class DataDrivenComponent implements OnInit {
-  @ViewChild('validatedRadioGroupRef', { read: ElementRef }) validatedRadioGroupRef;
   @ViewChild('displayRadioItemsBtnRef', { read: ElementRef }) displayRadioItemsBtnRef;
 
   constructor() { }
@@ -30,14 +29,6 @@ export class DataDrivenComponent implements OnInit {
 
   toggleRadioGroupDisplay() {
     this.radioGroupDisplay = !this.radioGroupDisplay;
-  }
-
-  validateRadioGroup() {
-    this.validatedRadioGroupRef.nativeElement.checkValidation();
-  }
-
-  clearRadioGroupValidation() {
-    this.validatedRadioGroupRef.nativeElement.clear();
   }
 
   generateRadioItems() {

--- a/angular-ids-wc/src/app/components/ids-radio/demos/deferred/deferred.component.css
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/deferred/deferred.component.css
@@ -1,0 +1,3 @@
+code.pre {
+  white-space: pre;
+}

--- a/angular-ids-wc/src/app/components/ids-radio/demos/deferred/deferred.component.html
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/deferred/deferred.component.html
@@ -1,0 +1,36 @@
+<ids-container language="en" locale="en-US" padding="8" hidden>
+  <ids-theme-switcher mode="light"></ids-theme-switcher>
+  
+  <ids-layout-grid cols="4" gap="md" padding-x="md">
+    <ids-layout-grid-cell>
+      <ids-text font-size="12" type="h1">&#64;deferred IdsRadioGroup/IdsRadios</ids-text><br />
+      <ids-button
+        #displayRadiosBtnRef
+        appearance="secondary"
+        (click)="isCheckedDeferred.set(true)"
+        text="Load Deferred Content"
+        [attr.disabled]="isCheckedDeferred()"></ids-button>
+      <br /><br />
+      @defer (when isCheckedDeferred()) {
+        <ids-radio-group 
+          #deferredRadioGroupRef 
+          label="Deferred Radio Group"
+          id="ids-radio-deferred"
+          (change)="onRadioChange($event)">
+          <ids-radio value="opt1" label="Option one"></ids-radio>
+          <ids-radio value="opt2" label="Option two"></ids-radio>
+          <ids-radio value="opt3" label="Option three" checked></ids-radio>
+        </ids-radio-group>
+      }
+      @placeholder {
+        <ids-text>No Radios have been loaded yet...</ids-text>
+      }
+      @error {
+        <ids-text>There was an error loading the radios...</ids-text>
+      }
+      @loading(minimum 1s) {
+        <ids-loading-indicator></ids-loading-indicator>
+      }
+    </ids-layout-grid-cell>
+  </ids-layout-grid>
+</ids-container>

--- a/angular-ids-wc/src/app/components/ids-radio/demos/deferred/deferred.component.spec.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/deferred/deferred.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeferredComponent } from './deferred.component';
+
+describe('DeferredComponent', () => {
+  let component: DeferredComponent;
+  let fixture: ComponentFixture<DeferredComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DeferredComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DeferredComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-ids-wc/src/app/components/ids-radio/demos/deferred/deferred.component.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/deferred/deferred.component.ts
@@ -1,0 +1,20 @@
+import { Component, ElementRef, ViewChild, signal } from '@angular/core';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: './deferred.component.html',
+  styleUrls: ['./deferred.component.css']
+})
+export class DeferredComponent {
+  @ViewChild('displayRadiosBtnRef', { read: ElementRef }) displayRadiosBtnRef;
+  @ViewChild('deferredRadioGroupRef', { read: ElementRef }) deferredRadioGroupRef;
+
+  isCheckedDeferred = signal(false);
+
+  constructor() { }
+
+  onRadioChange(event) {
+    const val = event.target.value;
+    console.info(`Radio Group updated checked value to ${val}`);
+  }
+}

--- a/angular-ids-wc/src/app/components/ids-radio/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/example/example.component.html
@@ -1,11 +1,11 @@
 <ids-container language="en" locale="en-US" padding="8" hidden>
   <ids-theme-switcher mode="light"></ids-theme-switcher>
   
-  <ids-layout-grid cols="3" gap="md">
+  <ids-layout-grid cols="3" gap="md" padding="md">
     <ids-text font-size="12" type="h1">Ids Radio</ids-text>
   </ids-layout-grid>
 
-  <ids-layout-grid cols="3" gap="md">
+  <ids-layout-grid cols="3" gap="md" padding-x="md">
     <ids-layout-grid-cell>
       <ids-radio-group label="Normal">
         <ids-radio value="opt1" label="Option one"></ids-radio>
@@ -24,44 +24,41 @@
       </ids-radio-group>
     </ids-layout-grid-cell>
     <ids-layout-grid-cell>
-      <ids-radio-group label="Dirty tracking" dirty-tracker="true">
-        <ids-radio value="opt1" label="Option one"></ids-radio>
-        <ids-radio value="opt2" label="Option two" checked="true"></ids-radio>
-        <ids-radio value="opt3" label="Option three" disabled="true"></ids-radio>
-        <ids-radio value="opt4" label="Option four"></ids-radio>
-      </ids-radio-group>
-
       <ids-radio-group label="Set Group Checked and Value" value="opt1">
         <ids-radio value="opt1" label="Option one"></ids-radio>
         <ids-radio value="opt2" label="Option two"></ids-radio>
       </ids-radio-group>
 
       <ids-radio-group label="Colored Radios">
-        <ids-radio color="emerald07" value="emerald07" label="Emerald 07"></ids-radio>
-        <ids-radio color="amethyst07" value="amethyst07" label="Amethyst 07"></ids-radio>
-        <ids-radio color="azure07" value="azure07" label="Azure 07"></ids-radio>
-        <ids-radio color="amber07" value="amber07" label="Amber 07" checked="true"></ids-radio>
-        <ids-radio color="ruby07" value="ruby07" label="Ruby 07"></ids-radio>
-        <ids-radio color="ruby07" value="ruby07d" label="Ruby 07 (disabled)" disabled="true"></ids-radio>
-        <ids-radio color="caution" value="caution" label="Caution"></ids-radio>
+        <ids-radio color="emerald" value="emerald" label="Emerald"></ids-radio>
+        <ids-radio color="amethyst" value="amethyst" label="Amethyst"></ids-radio>
+        <ids-radio color="azure" value="azure" label="Azure"></ids-radio>
+        <ids-radio color="amber" value="amber" label="Amber" checked="true"></ids-radio>
+        <ids-radio color="ruby" value="ruby" label="Ruby"></ids-radio>
+        <ids-radio color="ruby" value="ruby" label="Colored (disabled)" disabled="true"></ids-radio>
+        <ids-radio color="amber" value="caution" label="Caution"></ids-radio>
       </ids-radio-group>
 
     </ids-layout-grid-cell>
     <ids-layout-grid-cell>
-      <ids-radio-group label="Radio with Validation" validate="required" id="ids-radio-validation">
+      <ids-radio-group 
+        #validatedRadioGroupRef
+        label="Radio with Validation" 
+        validate="required" 
+        id="ids-radio-validation">
         <ids-radio value="opt1" label="Option one"></ids-radio>
         <ids-radio value="opt2" label="Option two"></ids-radio>
         <ids-radio value="opt3" label="Option three" disabled="true"></ids-radio>
       </ids-radio-group>
-      <ids-button appearance="secondary" id="btn-radio-clear">
+      <ids-button appearance="secondary" id="btn-radio-clear" (click)="clearRadioGroupValidation()">
         <span>Clear</span>
       </ids-button>
-      <ids-button appearance="secondary" id="btn-radio-validate">
+      <ids-button appearance="secondary" id="btn-radio-validate" (click)="validateRadioGroup()">
         <span>Validate</span>
       </ids-button>
 
       <br/><br/>
-      <ids-radio-group label="Horizontal Radio" horizontal="true">
+      <ids-radio-group label="Horizontal Radio" horizontal="true" validate="required">
         <ids-radio value="opt1" label="Option one"></ids-radio>
         <ids-radio value="opt2" label="Option two" checked="true"></ids-radio>
         <ids-radio value="opt3" label="Option three" disabled="true"></ids-radio>

--- a/angular-ids-wc/src/app/components/ids-radio/demos/example/example.component.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/example/example.component.ts
@@ -1,18 +1,14 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 
 @Component({
   selector: 'app-example',
   templateUrl: './example.component.html',
   styleUrls: ['./example.component.css']
 })
-export class ExampleComponent implements OnInit {
+export class ExampleComponent {
   @ViewChild('validatedRadioGroupRef', { read: ElementRef }) validatedRadioGroupRef;
 
   constructor() { }
-
-  ngOnInit(): void {
-
-  }
 
   validateRadioGroup() {
     this.validatedRadioGroupRef.nativeElement.checkValidation();

--- a/angular-ids-wc/src/app/components/ids-radio/demos/example/example.component.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/demos/example/example.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 
 @Component({
   selector: 'app-example',
@@ -6,10 +6,19 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./example.component.css']
 })
 export class ExampleComponent implements OnInit {
+  @ViewChild('validatedRadioGroupRef', { read: ElementRef }) validatedRadioGroupRef;
 
   constructor() { }
 
   ngOnInit(): void {
+
   }
 
+  validateRadioGroup() {
+    this.validatedRadioGroupRef.nativeElement.checkValidation();
+  }
+
+  clearRadioGroupValidation() {
+    this.validatedRadioGroupRef.nativeElement.clear();
+  }
 }

--- a/angular-ids-wc/src/app/components/ids-radio/ids-radio-routing.module.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/ids-radio-routing.module.ts
@@ -3,8 +3,9 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { IdsRadioComponent } from './ids-radio.component';
 import { ExampleComponent } from './demos/example/example.component';
-import { DataDrivenComponent } from './demos/data-driven/data-driven.component';
 import { ControlFlowComponent } from './demos/control-flow/control-flow.component';
+import { DataDrivenComponent } from './demos/data-driven/data-driven.component';
+import { DeferredComponent } from './demos/deferred/deferred.component';
 
 export const routes: Routes = [
   { 
@@ -22,6 +23,10 @@ export const routes: Routes = [
   {
     path: 'data-driven',
     component: DataDrivenComponent
+  },
+  {
+    path: 'deferred',
+    component: DeferredComponent
   }
 ];
 

--- a/angular-ids-wc/src/app/components/ids-radio/ids-radio-routing.module.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/ids-radio-routing.module.ts
@@ -4,6 +4,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { IdsRadioComponent } from './ids-radio.component';
 import { ExampleComponent } from './demos/example/example.component';
 import { DataDrivenComponent } from './demos/data-driven/data-driven.component';
+import { ControlFlowComponent } from './demos/control-flow/control-flow.component';
 
 export const routes: Routes = [
   { 
@@ -13,6 +14,10 @@ export const routes: Routes = [
   {
     path: 'example',
     component: ExampleComponent
+  },
+  {
+    path: 'control-flow',
+    component: ControlFlowComponent
   },
   {
     path: 'data-driven',

--- a/angular-ids-wc/src/app/components/ids-radio/ids-radio-routing.module.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/ids-radio-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { IdsRadioComponent } from './ids-radio.component';
 import { ExampleComponent } from './demos/example/example.component';
+import { DataDrivenComponent } from './demos/data-driven/data-driven.component';
 
 export const routes: Routes = [
   { 
@@ -12,6 +13,10 @@ export const routes: Routes = [
   {
     path: 'example',
     component: ExampleComponent
+  },
+  {
+    path: 'data-driven',
+    component: DataDrivenComponent
   }
 ];
 

--- a/angular-ids-wc/src/app/components/ids-radio/ids-radio.module.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/ids-radio.module.ts
@@ -4,8 +4,9 @@ import { CommonModule } from '@angular/common';
 import { IdsRadioRoutingModule } from './ids-radio-routing.module';
 import { IdsRadioComponent } from './ids-radio.component';
 import { ExampleComponent } from './demos/example/example.component';
-import { DataDrivenComponent } from './demos/data-driven/data-driven.component';
 import { ControlFlowComponent } from './demos/control-flow/control-flow.component';
+import { DataDrivenComponent } from './demos/data-driven/data-driven.component';
+import { DeferredComponent } from './demos/deferred/deferred.component';
 import { DemoListingModule } from '../demo-listing/demo-listing.module';
 
 @NgModule({
@@ -13,6 +14,7 @@ import { DemoListingModule } from '../demo-listing/demo-listing.module';
     IdsRadioComponent,
     ExampleComponent,
     DataDrivenComponent,
+    DeferredComponent,
     ControlFlowComponent
   ],
   imports: [

--- a/angular-ids-wc/src/app/components/ids-radio/ids-radio.module.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/ids-radio.module.ts
@@ -5,14 +5,15 @@ import { IdsRadioRoutingModule } from './ids-radio-routing.module';
 import { IdsRadioComponent } from './ids-radio.component';
 import { ExampleComponent } from './demos/example/example.component';
 import { DataDrivenComponent } from './demos/data-driven/data-driven.component';
+import { ControlFlowComponent } from './demos/control-flow/control-flow.component';
 import { DemoListingModule } from '../demo-listing/demo-listing.module';
-
 
 @NgModule({
   declarations: [
     IdsRadioComponent,
     ExampleComponent,
-    DataDrivenComponent
+    DataDrivenComponent,
+    ControlFlowComponent
   ],
   imports: [
     CommonModule,

--- a/angular-ids-wc/src/app/components/ids-radio/ids-radio.module.ts
+++ b/angular-ids-wc/src/app/components/ids-radio/ids-radio.module.ts
@@ -4,13 +4,15 @@ import { CommonModule } from '@angular/common';
 import { IdsRadioRoutingModule } from './ids-radio-routing.module';
 import { IdsRadioComponent } from './ids-radio.component';
 import { ExampleComponent } from './demos/example/example.component';
+import { DataDrivenComponent } from './demos/data-driven/data-driven.component';
 import { DemoListingModule } from '../demo-listing/demo-listing.module';
 
 
 @NgModule({
   declarations: [
     IdsRadioComponent,
-    ExampleComponent
+    ExampleComponent,
+    DataDrivenComponent
   ],
   imports: [
     CommonModule,

--- a/angular-ids-wc/src/utils/random.ts
+++ b/angular-ids-wc/src/utils/random.ts
@@ -1,0 +1,7 @@
+export function randomInt(max: number) { 
+  return Math.floor(Math.random() * max) 
+};
+
+export function randomBool() {
+  return Math.random() < 0.5;
+}


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds a handful of examples each for IdsCheckbox and IdsRadio to the Angular demo app:
- Adds a "data-driven" example demonstrating usage of each component with `ngIf/else`, `ngFor`, and `ngModel` directives.
- Adds a "control-flow" example that mimics the data-driven sample, but instead uses the [new "zoneless" control-flow blocks](https://www.angularaddicts.com/p/angular-17-new-control-flow-with-signals) introduced in Angular 17
- Adds a "deferred" example that demonstrates each component loading with [`@defer` and related blocks](https://www.angularaddicts.com/p/angular-17-feature-deferred-loading-with-signals), also introduced in Angular 17
- Also does some cleanup of existing demos, and a minor style improvement to make the NG demoapp look more like the standard one 

**Related github/jira issue(s) (required)**:
Closes infor-design/enterprise-wc#1644

**Steps necessary to review your pull request (required)**:
Pull/build/run, then test the following:

_IdsCheckbox main example:_
- Open http://localhost:4200/ids-checkbox/example
- See that this one now looks and behaves just like https://main.wc.design.infor.com/ids-checkbox/example.html

_IdsCheckbox data-driven example:_
- Open http://localhost:4200/ids-checkbox/data-driven
- There should be two empty states shown, "Checkboxes are currently hidden", and "No checkboxes were rendered (dataset is empty)
- Click the "Reveal Checkboxes" button to show/hide checkboxes (driven by an `ngIf` in the template)
- Click "Display Random Checkboxes" to generate a list of checkboxes backed by a dataset.  Some checkboxes are loaded checked or disabled by default.  Changing the checkbox state should also cause the `ngModel` output to update, since they are backed by the same model.

_IdsCheckbox control-flow example:_
- Open http://localhost:4200/ids-checkbox/control-flow
- This example is identical to `data-driven` but instead uses Angular 17's control flow syntax.  All behavior should be the same.

_IdsCheckbox deferred example:_
- Open http://localhost:4200/ids-checkbox/deferred
- There should be a message displayed: "No Checkbox has been loaded yet..." (displayed with `@placeholder`)
- Click "Load deferred content".  A loading indicator should appear (displayed with `@loading`)
- After about one second, a "deferred" IdsCheckbox should display and changing it should show a console message (displayed with `@defer`)

_IdsRadio main example:_
- Open http://localhost:4200/ids-radio/example
- See that this one now looks and behaves just like https://main.wc.design.infor.com/ids-radio/example.html

_IdsRadio data-driven example:_
- Open http://localhost:4200/ids-radio/data-driven
- There should be two empty states shown, "Radio Groups are currently hidden", and "No Radios were rendered (dataset is empty)
- Click the "Show Radio Groups" button to show/hide groups of radio buttons (driven by an `ngIf` in the template)
- Click "Display Random Radios" to generate a list of radios backed by a dataset.  Some radios are loaded disabled by default, and only one of the radios should be checked when loaded.  Changing the radio group's state should also cause the `ngModel` output to update, since they are backed by the same model.  It should only ever be possible that the output AND radio group have one item checked.

_IdsRadio control-flow example:_
- Open http://localhost:4200/ids-radio/control-flow
- This example is identical to `data-driven` but instead uses Angular 17's control flow syntax.  All behavior should be the same.

_IdsRadio deferred example:_
- Open http://localhost:4200/ids-radio/deferred
- There should be a message displayed: "No Radios have been loaded yet..." (displayed with `@placeholder`)
- Click "Load deferred content".  A loading indicator should appear (displayed with `@loading`)
- After about one second, a "deferred" IdsRadioGroup should display and changing its value should show a console message (displayed with `@defer`)

_Angular Demo App improvements:_
- Open http://localhost:4200/ids-checkbox and http://localhost:4200/ids-radio
- See that all the new examples are present, and the demoapp listing mimics the ones on https://main.wc.design.infor.com/ids-checkbox/ and https://main.wc.design.infor.com/ids-radio/.  It's currently a "known issue" that the "Example Type" and "Description" fields are empty (need a better way to handle these)