### PR TITLE
1577 - Demonstrate IdsScrollView/IdsLayoutGrid with dynamic data

### DIFF
--- a/angular-ids-wc/src/api/scroll-view-clocks-main.json
+++ b/angular-ids-wc/src/api/scroll-view-clocks-main.json
@@ -1,0 +1,42 @@
+[
+  [
+    {"name": "Clock1", "icon": "clock", "color": "azure"},
+    {"name": "Clock2", "icon": "clock", "color": "ruby"},
+    {"name": "Clock3", "icon": "clock", "color": "emerald"},
+    {"name": "Clock4", "icon": "clock", "color": false},
+    {"name": "Clock5", "icon": "clock", "color": "amethyst"},
+    {"name": "Clock6", "icon": "clock", "color": "amber"}
+  ],
+  [
+    {"name": "Clock7", "icon": "clock", "color": false},
+    {"name": "Clock8", "icon": "clock", "color": "emerald"},
+    {"name": "Clock9", "icon": "clock", "color": "amethyst"},
+    {"name": "Clock10", "icon": "clock", "color": "azure"},
+    {"name": "Clock11", "icon": "clock", "color": "ruby"},
+    {"name": "Clock12", "icon": "clock", "color": "amber"}
+  ],
+  [
+    {"name": "Clock13", "icon": "clock", "color": false},
+    {"name": "Clock14", "icon": "clock", "color": "emerald"},
+    {"name": "Clock15", "icon": "clock", "color": "amethyst"},
+    {"name": "Clock16", "icon": "clock", "color": "azure"},
+    {"name": "Clock17", "icon": "clock", "color": "ruby"},
+    {"name": "Clock18", "icon": "clock", "color": "amber"}
+  ],
+  [
+    {"name": "Clock19", "icon": "clock", "color": "azure"},
+    {"name": "Clock20", "icon": "clock", "color": "ruby"},
+    {"name": "Clock21", "icon": "clock", "color": false},
+    {"name": "Clock22", "icon": "clock", "color": "emerald"},
+    {"name": "Clock23", "icon": "clock", "color": "amethyst"},
+    {"name": "Clock24", "icon": "clock", "color": "amber"}
+  ],
+  [
+    {"name": "Clock25", "icon": "clock", "color": "ruby"},
+    {"name": "Clock26", "icon": "clock", "color": "emerald"},
+    {"name": "Clock27", "icon": "clock", "color": "amethyst"},
+    {"name": "Clock28", "icon": "clock", "color": "azure"},
+    {"name": "Clock29", "icon": "clock", "color": false},
+    {"name": "Clock30", "icon": "clock", "color": "amber"}
+  ]
+]

--- a/angular-ids-wc/src/api/scroll-view-clocks-secondary.json
+++ b/angular-ids-wc/src/api/scroll-view-clocks-secondary.json
@@ -1,0 +1,34 @@
+[
+  [
+    {"name": "Clock71", "icon": "clock", "color": "amethyst"},
+    {"name": "Clock72", "icon": "clock", "color": "azure"},
+    {"name": "Clock73", "icon": "clock", "color": "ruby"},
+    {"name": "Clock74", "icon": "clock", "color": false},
+    {"name": "Clock75", "icon": "clock", "color": "emerald"},
+    {"name": "Clock76", "icon": "clock", "color": "amber"}
+  ],
+  [
+    {"name": "Clock77", "icon": "clock", "color": "azure"},
+    {"name": "Clock78", "icon": "clock", "color": "ruby"},
+    {"name": "Clock79", "icon": "clock", "color": false},
+    {"name": "Clock80", "icon": "clock", "color": "emerald"},
+    {"name": "Clock81", "icon": "clock", "color": "amethyst"},
+    {"name": "Clock82", "icon": "clock", "color": "amber"}
+  ],
+  [
+    {"name": "Clock83", "icon": "clock", "color": "ruby"},
+    {"name": "Clock84", "icon": "clock", "color": "emerald"},
+    {"name": "Clock85", "icon": "clock", "color": "amethyst"},
+    {"name": "Clock86", "icon": "clock", "color": "azure"},
+    {"name": "Clock87", "icon": "clock", "color": false},
+    {"name": "Clock88", "icon": "clock", "color": "amber"}
+  ],
+  [
+    {"name": "Clock89", "icon": "clock", "color": "emerald"},
+    {"name": "Clock90", "icon": "clock", "color": "amethyst"},
+    {"name": "Clock91", "icon": "clock", "color": "azure"},
+    {"name": "Clock92", "icon": "clock", "color": "ruby"},
+    {"name": "Clock93", "icon": "clock", "color": false},
+    {"name": "Clock94", "icon": "clock", "color": "amber"}
+  ]
+]

--- a/angular-ids-wc/src/api/scroll-view-clocks-single.json
+++ b/angular-ids-wc/src/api/scroll-view-clocks-single.json
@@ -1,0 +1,7 @@
+[
+  [
+    {"name": "ClockA", "icon": "clock", "color": "ruby"}, 
+    {"name": "ClockB", "icon": "clock", "color": "amethyst"},
+    {"name": "ClockC", "icon": "clock", "color": "amber"}
+  ]
+]

--- a/angular-ids-wc/src/app/components/ids-scroll-view/demos/layout-grid/layout-grid.component.html
+++ b/angular-ids-wc/src/app/components/ids-scroll-view/demos/layout-grid/layout-grid.component.html
@@ -7,11 +7,11 @@
   <ids-layout-grid cols="1" cols-md="4" padding-x="md">
     <ids-layout-grid-cell col-span="1">
 
-      <ids-scroll-view #scrollView>
+      <ids-scroll-view #scrollView hide-on-one="true">
         <div *ngFor="let items of dataset" slot="scroll-view-item">
-          <ids-layout-grid cols="4" rows="3" cols-sm="12" rows-sm="2" gap="md" flow-sm="column" flow="row">
+          <ids-layout-grid cols-sm="12" rows-sm="2" gap="md" flow-sm="column" flow="row">
             <ids-layout-grid-cell col-span="2" *ngFor="let item of items">
-              <ids-icon [icon]="item.icon" height="128" width="128"></ids-icon>
+              <ids-icon [icon]="item.icon" [attr.status-color]="item.color" height="128" width="128"></ids-icon>
               <ids-text font-size="20" text-align="center">{{ item.name }}</ids-text>
             </ids-layout-grid-cell>
           </ids-layout-grid>
@@ -28,7 +28,14 @@
         id="toggle-dataset"
         appearance="secondary"
         [attr.text]="this.toggled ? 'Show original dataset' : 'Show alternate dataset'"
-        (click)="onDatasetChange()"></ids-button>
+        (click)="onDatasetToggle()"></ids-button>
+      <ids-button
+        #showOneItemBtn
+        id="show-one-item"
+        appearance="secondary"
+        text="Show one item"
+        [disabled]="this.singlePage"
+        (click)="onDisplayOneItem()"></ids-button>
       </ids-layout-grid-cell>
   </ids-layout-grid>
 </ids-container>

--- a/angular-ids-wc/src/app/components/ids-scroll-view/demos/layout-grid/layout-grid.component.html
+++ b/angular-ids-wc/src/app/components/ids-scroll-view/demos/layout-grid/layout-grid.component.html
@@ -4,14 +4,22 @@
   <ids-layout-grid auto-fit="true" padding="md">
     <ids-text font-size="12" type="h1">Scroll View (with Layout Grid)</ids-text>
   </ids-layout-grid>
-  <ids-layout-grid cols="1" cols-md="4" padding-x="md">
+  <ids-layout-grid cols="1" cols-md="1" padding-x="md">
     <ids-layout-grid-cell col-span="1">
 
       <ids-scroll-view #scrollView hide-on-one="true">
         <div *ngFor="let items of dataset" slot="scroll-view-item">
-          <ids-layout-grid cols-sm="12" rows-sm="2" gap="md" flow-sm="column" flow="row">
-            <ids-layout-grid-cell col-span="2" *ngFor="let item of items">
-              <ids-icon [icon]="item.icon" [attr.status-color]="item.color" height="128" width="128"></ids-icon>
+          <ids-layout-grid
+            auto-fit="true"
+            cols="4"
+            rows="3"
+            cols-sm="6"
+            rows-sm="2"
+            gap="md"
+            flow-sm="column"
+            flow="row">
+            <ids-layout-grid-cell col-span="2" *ngFor="let item of items" align-content="center">
+              <ids-icon [icon]="item.icon" [attr.status-color]="item.color || ''" height="128" width="128"></ids-icon>
               <ids-text font-size="20" text-align="center">{{ item.name }}</ids-text>
             </ids-layout-grid-cell>
           </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-scroll-view/demos/layout-grid/layout-grid.component.html
+++ b/angular-ids-wc/src/app/components/ids-scroll-view/demos/layout-grid/layout-grid.component.html
@@ -1,0 +1,34 @@
+<ids-container language="en" locale="en-US" padding="8" hidden>
+  <ids-theme-switcher mode="light"></ids-theme-switcher>
+  
+  <ids-layout-grid auto-fit="true" padding="md">
+    <ids-text font-size="12" type="h1">Scroll View (with Layout Grid)</ids-text>
+  </ids-layout-grid>
+  <ids-layout-grid cols="1" cols-md="4" padding-x="md">
+    <ids-layout-grid-cell col-span="1">
+
+      <ids-scroll-view #scrollView>
+        <div *ngFor="let items of dataset" slot="scroll-view-item">
+          <ids-layout-grid cols="4" rows="3" cols-sm="12" rows-sm="2" gap="md" flow-sm="column" flow="row">
+            <ids-layout-grid-cell col-span="2" *ngFor="let item of items">
+              <ids-icon [icon]="item.icon" height="128" width="128"></ids-icon>
+              <ids-text font-size="20" text-align="center">{{ item.name }}</ids-text>
+            </ids-layout-grid-cell>
+          </ids-layout-grid>
+        </div>
+      </ids-scroll-view>
+
+    </ids-layout-grid-cell>
+  </ids-layout-grid>
+
+  <ids-layout-grid cols="1" padding="md">
+    <ids-layout-grid-cell col-span="1">
+      <ids-button 
+        #toggleDatasetBtn
+        id="toggle-dataset"
+        appearance="secondary"
+        [attr.text]="this.toggled ? 'Show original dataset' : 'Show alternate dataset'"
+        (click)="onDatasetChange()"></ids-button>
+      </ids-layout-grid-cell>
+  </ids-layout-grid>
+</ids-container>

--- a/angular-ids-wc/src/app/components/ids-scroll-view/demos/layout-grid/layout-grid.component.spec.ts
+++ b/angular-ids-wc/src/app/components/ids-scroll-view/demos/layout-grid/layout-grid.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LayoutGridComponent } from './layout-grid.component';
+
+describe('LayoutGridComponent', () => {
+  let component: LayoutGridComponent;
+  let fixture: ComponentFixture<LayoutGridComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ LayoutGridComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(LayoutGridComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-ids-wc/src/app/components/ids-scroll-view/demos/layout-grid/layout-grid.component.ts
+++ b/angular-ids-wc/src/app/components/ids-scroll-view/demos/layout-grid/layout-grid.component.ts
@@ -2,29 +2,33 @@ import { Component, AfterViewInit, ViewChild, ElementRef, HostListener } from '@
 import { ActivatedRoute, Router } from '@angular/router'
 
 const item2DArray = [
-  [{"name": "Clock1", "icon": "clock"}, {"name": "Clock2", "icon": "clock"}],
-  [{"name": "Clock3", "icon": "clock"}, {"name": "Clock4", "icon": "clock"}],
-  [{"name": "Clock5", "icon": "clock"}, {"name": "Clock6", "icon": "clock"}],
-  [{"name": "Clock7", "icon": "clock"}, {"name": "Clock8", "icon": "clock"}],
-  [{"name": "Clock9", "icon": "clock"}, {"name": "Clock10", "icon": "clock"}],
-  [{"name": "Clock11", "icon": "clock"}, {"name": "Clock12", "icon": "clock"}],
-  [{"name": "Clock13", "icon": "clock"}, {"name": "Clock14", "icon": "clock"}],
-  [{"name": "Clock15", "icon": "clock"}, {"name": "Clock16", "icon": "clock"}],
-  [{"name": "Clock17", "icon": "clock"}, {"name": "Clock18", "icon": "clock"}],
-  [{"name": "Clock19", "icon": "clock"}, {"name": "Clock20", "icon": "clock"}]
+  [{"name": "Clock1", "icon": "clock", "color": "azure"}, {"name": "Clock2", "icon": "clock", "color": "ruby"}],
+  [{"name": "Clock3", "icon": "clock", "color": "emerald"}, {"name": "Clock4", "icon": "clock", "color": false}],
+  [{"name": "Clock5", "icon": "clock", "color": "amethyst"}, {"name": "Clock6", "icon": "clock", "color": "azure"}],
+  [{"name": "Clock7", "icon": "clock", "color": "ruby"}, {"name": "Clock8", "icon": "clock", "color": false}],
+  [{"name": "Clock9", "icon": "clock", "color": "emerald"}, {"name": "Clock10", "icon": "clock", "color": "amethyst"}],
+  [{"name": "Clock11", "icon": "clock", "color": false}, {"name": "Clock12", "icon": "clock", "color": "azure"}],
+  [{"name": "Clock13", "icon": "clock", "color": "ruby"}, {"name": "Clock14", "icon": "clock", "color": false}],
+  [{"name": "Clock15", "icon": "clock", "color": "emerald"}, {"name": "Clock16", "icon": "clock", "color": "amethyst"}],
+  [{"name": "Clock17", "icon": "clock", "color": "azure"}, {"name": "Clock18", "icon": "clock", "color": "ruby"}],
+  [{"name": "Clock19", "icon": "clock", "color": false}, {"name": "Clock20", "icon": "clock", "color": "emerald"}]
 ];
 
 const alternateItem2DArray = [
-  [{"name": "Clock65", "icon": "clock"}, {"name": "Clock66", "icon": "clock"}],
-  [{"name": "Clock67", "icon": "clock"}, {"name": "Clock68", "icon": "clock"}],
-  [{"name": "Clock69", "icon": "clock"}, {"name": "Clock70", "icon": "clock"}],
-  [{"name": "Clock71", "icon": "clock"}, {"name": "Clock72", "icon": "clock"}],
-  [{"name": "Clock73", "icon": "clock"}, {"name": "Clock74", "icon": "clock"}],
-  [{"name": "Clock75", "icon": "clock"}, {"name": "Clock76", "icon": "clock"}],
-  [{"name": "Clock77", "icon": "clock"}, {"name": "Clock78", "icon": "clock"}],
-  [{"name": "Clock79", "icon": "clock"}, {"name": "Clock80", "icon": "clock"}],
-  [{"name": "Clock81", "icon": "clock"}, {"name": "Clock82", "icon": "clock"}],
-  [{"name": "Clock83", "icon": "clock"}, {"name": "Clock84", "icon": "clock"}]
+  [{"name": "Clock65", "icon": "clock", "color": "amethyst"}, {"name": "Clock66", "icon": "clock", "color": false}],
+  [{"name": "Clock67", "icon": "clock", "color": "azure"}, {"name": "Clock68", "icon": "clock", "color": "ruby"}],
+  [{"name": "Clock69", "icon": "clock", "color": false}, {"name": "Clock70", "icon": "clock", "color": "emerald"}],
+  [{"name": "Clock71", "icon": "clock", "color": "amethyst"}, {"name": "Clock72", "icon": "clock", "color": "azure"}],
+  [{"name": "Clock73", "icon": "clock", "color": "ruby"}, {"name": "Clock74", "icon": "clock", "color": false}],
+  [{"name": "Clock75", "icon": "clock", "color": "emerald"}, {"name": "Clock76", "icon": "clock", "color": "amethyst"}],
+  [{"name": "Clock77", "icon": "clock", "color": "azure"}, {"name": "Clock78", "icon": "clock", "color": "ruby"}],
+  [{"name": "Clock79", "icon": "clock", "color": false}, {"name": "Clock80", "icon": "clock", "color": "emerald"}],
+  [{"name": "Clock81", "icon": "clock", "color": "amethyst"}, {"name": "Clock82", "icon": "clock", "color": "azure"}],
+  [{"name": "Clock83", "icon": "clock", "color": "ruby"}, {"name": "Clock84", "icon": "clock", "color": false}]
+];
+
+const singlePage2DArray = [
+  [{"name": "Clock1", "icon": "clock", "color": "ruby"}, {"name": "Clock2", "icon": "clock", "color": "amethyst"}]
 ];
 
 @Component({
@@ -38,6 +42,7 @@ export class LayoutGridComponent implements AfterViewInit {
 
   dataset = item2DArray;
   toggled = false;
+  singlePage = false;
 
   constructor(
     private router: Router
@@ -47,9 +52,26 @@ export class LayoutGridComponent implements AfterViewInit {
     console.log('IdsScrollView AfterViewInit')
   }
 
-  onDatasetChange() {
+  /** 
+   * Switches the datasets.  If the single page button is clicked,
+   * The dataset displayed will always be the "alternate".
+   */
+  onDatasetToggle() {
+    if (this.singlePage) {
+      this.toggled = false;
+      this.singlePage = false;
+    }
     this.toggled = !this.toggled;
     this.dataset = this.toggled ? alternateItem2DArray : item2DArray;
     console.log('dataset toggle: ', this.toggled);
+  }
+
+  /**
+   * Forces the displayed dataset to only have one item.
+   */
+  onDisplayOneItem() {
+    this.dataset = singlePage2DArray;
+    this.singlePage = true;
+    console.log('showing one dataset item');
   }
 }

--- a/angular-ids-wc/src/app/components/ids-scroll-view/demos/layout-grid/layout-grid.component.ts
+++ b/angular-ids-wc/src/app/components/ids-scroll-view/demos/layout-grid/layout-grid.component.ts
@@ -1,0 +1,55 @@
+import { Component, AfterViewInit, ViewChild, ElementRef, HostListener } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router'
+
+const item2DArray = [
+  [{"name": "Clock1", "icon": "clock"}, {"name": "Clock2", "icon": "clock"}],
+  [{"name": "Clock3", "icon": "clock"}, {"name": "Clock4", "icon": "clock"}],
+  [{"name": "Clock5", "icon": "clock"}, {"name": "Clock6", "icon": "clock"}],
+  [{"name": "Clock7", "icon": "clock"}, {"name": "Clock8", "icon": "clock"}],
+  [{"name": "Clock9", "icon": "clock"}, {"name": "Clock10", "icon": "clock"}],
+  [{"name": "Clock11", "icon": "clock"}, {"name": "Clock12", "icon": "clock"}],
+  [{"name": "Clock13", "icon": "clock"}, {"name": "Clock14", "icon": "clock"}],
+  [{"name": "Clock15", "icon": "clock"}, {"name": "Clock16", "icon": "clock"}],
+  [{"name": "Clock17", "icon": "clock"}, {"name": "Clock18", "icon": "clock"}],
+  [{"name": "Clock19", "icon": "clock"}, {"name": "Clock20", "icon": "clock"}]
+];
+
+const alternateItem2DArray = [
+  [{"name": "Clock65", "icon": "clock"}, {"name": "Clock66", "icon": "clock"}],
+  [{"name": "Clock67", "icon": "clock"}, {"name": "Clock68", "icon": "clock"}],
+  [{"name": "Clock69", "icon": "clock"}, {"name": "Clock70", "icon": "clock"}],
+  [{"name": "Clock71", "icon": "clock"}, {"name": "Clock72", "icon": "clock"}],
+  [{"name": "Clock73", "icon": "clock"}, {"name": "Clock74", "icon": "clock"}],
+  [{"name": "Clock75", "icon": "clock"}, {"name": "Clock76", "icon": "clock"}],
+  [{"name": "Clock77", "icon": "clock"}, {"name": "Clock78", "icon": "clock"}],
+  [{"name": "Clock79", "icon": "clock"}, {"name": "Clock80", "icon": "clock"}],
+  [{"name": "Clock81", "icon": "clock"}, {"name": "Clock82", "icon": "clock"}],
+  [{"name": "Clock83", "icon": "clock"}, {"name": "Clock84", "icon": "clock"}]
+];
+
+@Component({
+  selector: 'app-example',
+  templateUrl: './layout-grid.component.html',
+  styleUrls: ['./layout-grid.component.css']
+})
+export class LayoutGridComponent implements AfterViewInit {
+  @ViewChild('scrollview', { read: ElementRef }) scrollview;
+  @ViewChild('toggleDatasetBtn', { read: ElementRef }) toggleDatasetBtn;
+
+  dataset = item2DArray;
+  toggled = false;
+
+  constructor(
+    private router: Router
+  ) { }
+
+  ngAfterViewInit(): void {
+    console.log('IdsScrollView AfterViewInit')
+  }
+
+  onDatasetChange() {
+    this.toggled = !this.toggled;
+    this.dataset = this.toggled ? alternateItem2DArray : item2DArray;
+    console.log('dataset toggle: ', this.toggled);
+  }
+}

--- a/angular-ids-wc/src/app/components/ids-scroll-view/demos/layout-grid/layout-grid.component.ts
+++ b/angular-ids-wc/src/app/components/ids-scroll-view/demos/layout-grid/layout-grid.component.ts
@@ -1,46 +1,16 @@
-import { Component, AfterViewInit, ViewChild, ElementRef, HostListener } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router'
-
-const item2DArray = [
-  [{"name": "Clock1", "icon": "clock", "color": "azure"}, {"name": "Clock2", "icon": "clock", "color": "ruby"}],
-  [{"name": "Clock3", "icon": "clock", "color": "emerald"}, {"name": "Clock4", "icon": "clock", "color": false}],
-  [{"name": "Clock5", "icon": "clock", "color": "amethyst"}, {"name": "Clock6", "icon": "clock", "color": "azure"}],
-  [{"name": "Clock7", "icon": "clock", "color": "ruby"}, {"name": "Clock8", "icon": "clock", "color": false}],
-  [{"name": "Clock9", "icon": "clock", "color": "emerald"}, {"name": "Clock10", "icon": "clock", "color": "amethyst"}],
-  [{"name": "Clock11", "icon": "clock", "color": false}, {"name": "Clock12", "icon": "clock", "color": "azure"}],
-  [{"name": "Clock13", "icon": "clock", "color": "ruby"}, {"name": "Clock14", "icon": "clock", "color": false}],
-  [{"name": "Clock15", "icon": "clock", "color": "emerald"}, {"name": "Clock16", "icon": "clock", "color": "amethyst"}],
-  [{"name": "Clock17", "icon": "clock", "color": "azure"}, {"name": "Clock18", "icon": "clock", "color": "ruby"}],
-  [{"name": "Clock19", "icon": "clock", "color": false}, {"name": "Clock20", "icon": "clock", "color": "emerald"}]
-];
-
-const alternateItem2DArray = [
-  [{"name": "Clock65", "icon": "clock", "color": "amethyst"}, {"name": "Clock66", "icon": "clock", "color": false}],
-  [{"name": "Clock67", "icon": "clock", "color": "azure"}, {"name": "Clock68", "icon": "clock", "color": "ruby"}],
-  [{"name": "Clock69", "icon": "clock", "color": false}, {"name": "Clock70", "icon": "clock", "color": "emerald"}],
-  [{"name": "Clock71", "icon": "clock", "color": "amethyst"}, {"name": "Clock72", "icon": "clock", "color": "azure"}],
-  [{"name": "Clock73", "icon": "clock", "color": "ruby"}, {"name": "Clock74", "icon": "clock", "color": false}],
-  [{"name": "Clock75", "icon": "clock", "color": "emerald"}, {"name": "Clock76", "icon": "clock", "color": "amethyst"}],
-  [{"name": "Clock77", "icon": "clock", "color": "azure"}, {"name": "Clock78", "icon": "clock", "color": "ruby"}],
-  [{"name": "Clock79", "icon": "clock", "color": false}, {"name": "Clock80", "icon": "clock", "color": "emerald"}],
-  [{"name": "Clock81", "icon": "clock", "color": "amethyst"}, {"name": "Clock82", "icon": "clock", "color": "azure"}],
-  [{"name": "Clock83", "icon": "clock", "color": "ruby"}, {"name": "Clock84", "icon": "clock", "color": false}]
-];
-
-const singlePage2DArray = [
-  [{"name": "Clock1", "icon": "clock", "color": "ruby"}, {"name": "Clock2", "icon": "clock", "color": "amethyst"}]
-];
+import { Component, AfterViewInit, OnInit, ViewChild, ElementRef } from '@angular/core';
+import { Router } from '@angular/router'
 
 @Component({
   selector: 'app-example',
   templateUrl: './layout-grid.component.html',
   styleUrls: ['./layout-grid.component.css']
 })
-export class LayoutGridComponent implements AfterViewInit {
+export class LayoutGridComponent implements OnInit, AfterViewInit {
   @ViewChild('scrollview', { read: ElementRef }) scrollview;
   @ViewChild('toggleDatasetBtn', { read: ElementRef }) toggleDatasetBtn;
 
-  dataset = item2DArray;
+  dataset = [];
   toggled = false;
   singlePage = false;
 
@@ -48,8 +18,25 @@ export class LayoutGridComponent implements AfterViewInit {
     private router: Router
   ) { }
 
+  private layoutGridDataDictionary = {
+    primary: '/api/scroll-view-clocks-main.json',
+    secondary: '/api/scroll-view-clocks-secondary.json',
+    single: '/api/scroll-view-clocks-single.json'
+  }
+
+  private async loadLayoutGridData(type: string) {
+    const layoutGridRes = await fetch(this.layoutGridDataDictionary[type]);
+    const layoutGridData = await layoutGridRes.json();
+    this.dataset = layoutGridData;
+  }
+
+  ngOnInit(): void {
+    console.log('IdsScrollView OnInit');
+    this.loadLayoutGridData('primary');
+  }
+
   ngAfterViewInit(): void {
-    console.log('IdsScrollView AfterViewInit')
+    console.log('IdsScrollView AfterViewInit');
   }
 
   /** 
@@ -62,16 +49,18 @@ export class LayoutGridComponent implements AfterViewInit {
       this.singlePage = false;
     }
     this.toggled = !this.toggled;
-    this.dataset = this.toggled ? alternateItem2DArray : item2DArray;
-    console.log('dataset toggle: ', this.toggled);
+    const targetDataset = this.toggled ? 'secondary' : 'primary';
+
+    this.loadLayoutGridData(targetDataset);
+    console.log('dataset toggle: ', targetDataset);
   }
 
   /**
    * Forces the displayed dataset to only have one item.
    */
   onDisplayOneItem() {
-    this.dataset = singlePage2DArray;
+    this.loadLayoutGridData('single');
     this.singlePage = true;
-    console.log('showing one dataset item');
+    console.log('dataset toggle: single');
   }
 }

--- a/angular-ids-wc/src/app/components/ids-scroll-view/ids-scroll-view-routing.module.ts
+++ b/angular-ids-wc/src/app/components/ids-scroll-view/ids-scroll-view-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { IdsScrollViewComponent } from './ids-scroll-view.component';
 import { ExampleComponent } from './demos/example/example.component';
+import { LayoutGridComponent } from './demos/layout-grid/layout-grid.component';
 
 export const routes: Routes = [
   { 
@@ -12,6 +13,10 @@ export const routes: Routes = [
   { 
     path: 'example',
     component: ExampleComponent 
+  },
+  {
+    path: 'layout-grid',
+    component: LayoutGridComponent
   }
 ];
 

--- a/angular-ids-wc/src/app/components/ids-scroll-view/ids-scroll-view.module.ts
+++ b/angular-ids-wc/src/app/components/ids-scroll-view/ids-scroll-view.module.ts
@@ -4,13 +4,15 @@ import { CommonModule } from '@angular/common';
 import { IdsScrollViewRoutingModule } from './ids-scroll-view-routing.module';
 import { IdsScrollViewComponent } from './ids-scroll-view.component';
 import { ExampleComponent } from './demos/example/example.component';
+import { LayoutGridComponent } from './demos/layout-grid/layout-grid.component';
 import { DemoListingModule } from '../demo-listing/demo-listing.module';
 
 
 @NgModule({
   declarations: [
     IdsScrollViewComponent,
-    ExampleComponent
+    ExampleComponent,
+    LayoutGridComponent
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR adds a demo of IdsScrollView working with IdsLayoutGrid, and tests some key features:
- Demos dynamic datasets in IdsScrollView, switching between datasets of varying size
- Shows a fix made to IdsScrollView which properly selects the "first" page as current when the dataset is swapped.
- Demos the new `hide-on-one` setting, which hides the circle buttons when only a single page is present.

**Related github/jira issue(s) (required)**:
Closes infor-design/enterprise-wc#1577

**Steps necessary to review your pull request (required)**:
- Pull this branch
- Ensure infor-design/enterprise-wc#1690 is merged, or `npm link` a local copy of that branch to this project
- Build and open http://localhost:4200/ids-scroll-view/layout-grid
- Use circle buttons to select any other page besides the first one
- Click "Show alternate dataset" to dynamically change dataset.  After it loads, the scroll view should reset to the first page.
- Click "Show one item" to show a single page.  The circle buttons should visually "hide".
- Click "Show original dataset".  The circle buttons should re-appear, and page 1 should still be set.
- Also double check http://localhost:4200/ids-scroll-view/example for accuracy. 