### PR TITLE
1693 - ids-checkbox and ids-checkbox-group values aren't correct in angular

### DIFF
--- a/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.html
@@ -19,17 +19,7 @@
 
         <ids-date-picker label="IDS Date Picker (string)" tabbable="false" mask formControlName="testDateString" ngDefaultControl></ids-date-picker>
 
-        <ids-dropdown label="IDS Dropdown" validate="required" formControlName="testDropdown" ngDefaultControl>
-          <ids-list-box>
-            <ids-list-box-option value="blank" id="blank" aria-label="Blank"></ids-list-box-option>
-            <ids-list-box-option value="opt1" id="opt1-d4">Option One</ids-list-box-option>
-            <ids-list-box-option value="opt2" id="opt2-d4">Option Two</ids-list-box-option>
-            <ids-list-box-option value="opt3" id="opt3-d4">Option Three</ids-list-box-option>
-            <ids-list-box-option value="opt4" id="opt4-d4">Option Four</ids-list-box-option>
-            <ids-list-box-option value="opt5" id="opt5-d4">Option Five</ids-list-box-option>
-            <ids-list-box-option value="opt6" id="opt6-d4">Option Six</ids-list-box-option>
-          </ids-list-box>
-        </ids-dropdown>
+        <ids-time-picker label="IDS Time Picker" id="e2e-timepicker-autoselect" autoselect mask="true" formControlName="testTimePicker" ngDefaultControl></ids-time-picker>
 
         <ids-input type="text" label="IDS Input" formControlName="testInput" ngDefaultControl></ids-input>
 
@@ -42,7 +32,17 @@
         <br>
         <br>
 
-        <ids-time-picker label="IDS Time Picker" id="e2e-timepicker-autoselect" autoselect mask="true" formControlName="testTimePicker" ngDefaultControl></ids-time-picker>
+        <ids-dropdown label="IDS Dropdown" validate="required" formControlName="testDropdown" ngDefaultControl>
+          <ids-list-box>
+            <ids-list-box-option value="blank" id="blank" aria-label="Blank"></ids-list-box-option>
+            <ids-list-box-option value="opt1" id="opt1-d4">Option One</ids-list-box-option>
+            <ids-list-box-option value="opt2" id="opt2-d4">Option Two</ids-list-box-option>
+            <ids-list-box-option value="opt3" id="opt3-d4">Option Three</ids-list-box-option>
+            <ids-list-box-option value="opt4" id="opt4-d4">Option Four</ids-list-box-option>
+            <ids-list-box-option value="opt5" id="opt5-d4">Option Five</ids-list-box-option>
+            <ids-list-box-option value="opt6" id="opt6-d4">Option Six</ids-list-box-option>
+          </ids-list-box>
+        </ids-dropdown>
 
         <ids-radio-group label="IDS Radio Group" formControlName="testRadio" ngDefaultControl>
           <ids-radio value="radio1" label="radio one"></ids-radio>

--- a/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.html
@@ -6,10 +6,14 @@
         <ids-text font-size="12" type="h1">Reactive forms</ids-text>
         <br>
 
-        <ids-checkbox-group label="IDS Checkbox Group" formControlName="testCheckbox" ngDefaultControl>
+        <ids-checkbox value="checkbox0" label="IDS Checkbox" formControlName="testCheckbox" ngDefaultControl></ids-checkbox>
+        <br>
+
+        <ids-checkbox-group label="IDS Checkbox Group" formControlName="testCheckboxGroup" ngDefaultControl>
           <ids-checkbox value="checkbox1" label="checkbox one"></ids-checkbox>
-          <ids-checkbox value="checkbox2" label="checkbox two" checked="true"></ids-checkbox>
+          <ids-checkbox value="checkbox2" label="checkbox two"></ids-checkbox>
         </ids-checkbox-group>
+        <br>
 
         <ids-date-picker label="IDS Date Picker (object)" tabbable="false" mask formControlName="testDateObject" ngDefaultControl></ids-date-picker>
 

--- a/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.html
@@ -53,7 +53,7 @@
 
         <ids-spinbox label="IDS Spinbox" value="0" formControlName="testSpinbox" ngDefaultControl></ids-spinbox>
 
-        <ids-switch label="IDS Switch" formControlName="testSwitch" ngDefaultControl></ids-switch><ids-button id="update" (click)="updateModel()">Update Booleans</ids-button>
+        <ids-switch label="IDS Switch" formControlName="testSwitch" ngDefaultControl></ids-switch>
 
         <ids-upload label="IDS Upload" formControlName="testUpload" ngDefaultControl></ids-upload>
 
@@ -72,6 +72,7 @@
             <ids-input type="text" label="Autoselect" value="Text select on focus" autoselect="true"></ids-input>
             -->
           <button type="submit">Submit</button>
+          <ids-button id="update" (click)="updateModel()">Update Values</ids-button>
         </ids-layout-grid-cell>
       </ids-layout-grid>
     </ids-layout-grid>

--- a/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.html
@@ -53,7 +53,7 @@
 
         <ids-spinbox label="IDS Spinbox" value="0" formControlName="testSpinbox" ngDefaultControl></ids-spinbox>
 
-        <ids-switch label="IDS Switch" formControlName="testSwitch" ngDefaultControl></ids-switch><ids-button id="update" (click)="updateModel()">Update</ids-button>
+        <ids-switch label="IDS Switch" formControlName="testSwitch" ngDefaultControl></ids-switch><ids-button id="update" (click)="updateModel()">Update Booleans</ids-button>
 
         <ids-upload label="IDS Upload" formControlName="testUpload" ngDefaultControl></ids-upload>
 

--- a/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
@@ -62,7 +62,7 @@ export class ExampleComponent implements OnInit {
     this.testForm.controls['testDateString'].setValue((new Date()).toDateString());
     this.testForm.controls['testDropdown'].setValue(!this.testForm.controls['testDropdown'].value);
     this.testForm.controls['testInput'].setValue(randomText(2));
-    this.testForm.controls['testLookup'].setValue(!this.testForm.controls['testLookup'].value);
+    this.testForm.controls['testLookup'].setValue(randomText(2));
     this.testForm.controls['testTextarea'].setValue(randomText(9));
     this.testForm.controls['testTimePicker'].setValue(!this.testForm.controls['testTimePicker'].value);
     this.testForm.controls['testRadio'].setValue(!this.testForm.controls['testRadio'].value);

--- a/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
@@ -57,6 +57,7 @@ export class ExampleComponent implements OnInit {
 
   public updateModel() {
     const randomText = (wordCount) => Array(wordCount).fill(Math.random().toString(32).substring(2)).join(' ');
+    const randomDate = () => new Date(Math.floor(Math.random()*(10**12.5)));
 
     const nextDropdownValue = {
       blank: 'opt1',
@@ -73,22 +74,26 @@ export class ExampleComponent implements OnInit {
       radio2: 'radio1',
     }[this.testForm.controls['testRadio'].value] ?? 'radio1';
 
-    this.testForm.controls['testDateObject'].setValue(new Date());
-    this.testForm.controls['testDateString'].setValue((new Date()).toDateString());
-    this.testForm.controls['testDropdown'].setValue(nextDropdownValue);
-    this.testForm.controls['testInput'].setValue(randomText(2));
-    this.testForm.controls['testLookup'].setValue(randomText(2));
-    this.testForm.controls['testTextarea'].setValue(randomText(9));
-    this.testForm.controls['testTimePicker'].setValue(!this.testForm.controls['testTimePicker'].value);
-    this.testForm.controls['testRadio'].setValue(nextRadioValue);
-    this.testForm.controls['testSearchField'].setValue(randomText(3));
-    this.testForm.controls['testSpinbox'].setValue(Math.floor(Math.random() * 100));
-    this.testForm.controls['testUpload'].setValue(`${randomText(2).split(' ').join('/')}.txt`);
-    this.testForm.controls['testUploadAdvanced'].setValue(`${randomText(3).split(' ').join('/')}.txt`);
-
     this.testForm.controls['testSwitch'].setValue(!this.testForm.controls['testSwitch'].value);
     this.testForm.controls['testCheckbox'].setValue(!this.testForm.controls['testCheckbox'].value);
     this.testForm.controls['testCheckboxGroup'].setValue(!this.testForm.controls['testCheckboxGroup'].value);
+
+    this.testForm.controls['testDateObject'].setValue(randomDate());
+    this.testForm.controls['testDateString'].setValue(randomDate().toLocaleDateString());
+    this.testForm.controls['testTimePicker'].setValue(randomDate().toLocaleTimeString());
+
+    this.testForm.controls['testInput'].setValue(randomText(2));
+    this.testForm.controls['testLookup'].setValue(randomText(2));
+    this.testForm.controls['testTextarea'].setValue(randomText(9));
+    this.testForm.controls['testSearchField'].setValue(randomText(3));
+
+    this.testForm.controls['testDropdown'].setValue(nextDropdownValue);
+    this.testForm.controls['testRadio'].setValue(nextRadioValue);
+
+    this.testForm.controls['testSpinbox'].setValue(Math.floor(Math.random() * 100));
+
+    this.testForm.controls['testUpload'].setValue(`${randomText(2).split(' ').join('/')}.txt`);
+    this.testForm.controls['testUploadAdvanced'].setValue(`${randomText(3).split(' ').join('/')}.txt`);
 
     this.onFormSubmit();
   }

--- a/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
@@ -58,14 +58,29 @@ export class ExampleComponent implements OnInit {
   public updateModel() {
     const randomText = (wordCount) => Array(wordCount).fill(Math.random().toString(32).substring(2)).join(' ');
 
+    const nextDropdownValue = {
+      blank: 'opt1',
+      opt1: 'opt2',
+      opt2: 'opt3',
+      opt3: 'opt4',
+      opt4: 'opt5',
+      opt5: 'opt6',
+      opt6: 'blank',
+    }[this.testForm.controls['testDropdown'].value] ?? 'opt1';
+
+    const nextRadioValue = {
+      radio1: 'radio2',
+      radio2: 'radio1',
+    }[this.testForm.controls['testRadio'].value] ?? 'radio1';
+
     this.testForm.controls['testDateObject'].setValue(new Date());
     this.testForm.controls['testDateString'].setValue((new Date()).toDateString());
-    this.testForm.controls['testDropdown'].setValue(!this.testForm.controls['testDropdown'].value);
+    this.testForm.controls['testDropdown'].setValue(nextDropdownValue);
     this.testForm.controls['testInput'].setValue(randomText(2));
     this.testForm.controls['testLookup'].setValue(randomText(2));
     this.testForm.controls['testTextarea'].setValue(randomText(9));
     this.testForm.controls['testTimePicker'].setValue(!this.testForm.controls['testTimePicker'].value);
-    this.testForm.controls['testRadio'].setValue(!this.testForm.controls['testRadio'].value);
+    this.testForm.controls['testRadio'].setValue(nextRadioValue);
     this.testForm.controls['testSearchField'].setValue(randomText(3));
     this.testForm.controls['testSpinbox'].setValue(Math.floor(Math.random() * 100));
     this.testForm.controls['testUpload'].setValue(`${randomText(2).split(' ').join('/')}.txt`);

--- a/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
@@ -56,9 +56,26 @@ export class ExampleComponent implements OnInit {
   }
 
   public updateModel() {
+    const randomText = (wordCount) => Array(wordCount).fill(Math.random().toString(32).substring(2)).join(' ');
+
+    this.testForm.controls['testDateObject'].setValue(new Date());
+    this.testForm.controls['testDateString'].setValue((new Date()).toDateString());
+    this.testForm.controls['testDropdown'].setValue(!this.testForm.controls['testDropdown'].value);
+    this.testForm.controls['testInput'].setValue(randomText(2));
+    this.testForm.controls['testLookup'].setValue(!this.testForm.controls['testLookup'].value);
+    this.testForm.controls['testTextarea'].setValue(randomText(9));
+    this.testForm.controls['testTimePicker'].setValue(!this.testForm.controls['testTimePicker'].value);
+    this.testForm.controls['testRadio'].setValue(!this.testForm.controls['testRadio'].value);
+    this.testForm.controls['testSearchField'].setValue(randomText(3));
+    this.testForm.controls['testSpinbox'].setValue(!this.testForm.controls['testSpinbox'].value);
+    this.testForm.controls['testUpload'].setValue(!this.testForm.controls['testUpload'].value);
+    this.testForm.controls['testUploadAdvanced'].setValue(!this.testForm.controls['testUploadAdvanced'].value);
+
     this.testForm.controls['testSwitch'].setValue(!this.testForm.controls['testSwitch'].value);
     this.testForm.controls['testCheckbox'].setValue(!this.testForm.controls['testCheckbox'].value);
     this.testForm.controls['testCheckboxGroup'].setValue(!this.testForm.controls['testCheckboxGroup'].value);
+
+    this.onFormSubmit();
   }
 
 }

--- a/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
@@ -33,21 +33,26 @@ export class ExampleComponent implements OnInit {
   }
 
   public onFormSubmit() {
-    console.log(`testCheckbox selected is: ${this.testForm.controls['testCheckbox'].value}`);
-    console.log(`testCheckboxGroup selected is: ${this.testForm.controls['testCheckboxGroup'].value}`);
-    console.log(`testDateObject entered is: ${this.testForm.controls['testDateObject'].value}`);
-    console.log(`testDateString entered is: ${this.testForm.controls['testDateString'].value}`);
-    console.log(`testDropdown selected is: ${this.testForm.controls['testDropdown'].value}`);
-    console.log(`testInput entered is: ${this.testForm.controls['testInput'].value}`);
-    console.log(`testLookup entered is: ${this.testForm.controls['testLookup'].value}`);
-    console.log(`testTextarea entered is: ${this.testForm.controls['testTextarea'].value}`);
-    console.log(`testTimePicker entered is: ${this.testForm.controls['testTimePicker'].value}`);
-    console.log(`testRadio selected is: ${this.testForm.controls['testRadio'].value}`);
-    console.log(`testSearchField selected is: ${this.testForm.controls['testSearchField'].value}`);
-    console.log(`testSpinbox selected is: ${this.testForm.controls['testSpinbox'].value}`);
-    console.log(`testSwitch selected is: ${this.testForm.controls['testSwitch'].value}`);
-    console.log(`testUpload selected is: ${this.testForm.controls['testUpload'].value}`);
-    console.log(`testUploadAdvanced selected is: ${this.testForm.controls['testUploadAdvanced'].value}`);
+    console.log(`FormControl(testCheckbox) value is: ${this.testForm.controls['testCheckbox'].value}`);
+    console.log(`FormControl(testCheckboxGroup) value is: ${this.testForm.controls['testCheckboxGroup'].value}`);
+    console.log(`FormControl(testDateObject) value is: ${this.testForm.controls['testDateObject'].value}`);
+    console.log(`FormControl(testDateString) value is: ${this.testForm.controls['testDateString'].value}`);
+    console.log(`FormControl(testDropdown) value is: ${this.testForm.controls['testDropdown'].value}`);
+    console.log(`FormControl(testInput) value is: ${this.testForm.controls['testInput'].value}`);
+    console.log(`FormControl(testLookup) value is: ${this.testForm.controls['testLookup'].value}`);
+    console.log(`FormControl(testTextarea) value is: ${this.testForm.controls['testTextarea'].value}`);
+    console.log(`FormControl(testTimePicker) value is: ${this.testForm.controls['testTimePicker'].value}`);
+    console.log(`FormControl(testRadio) value is: ${this.testForm.controls['testRadio'].value}`);
+    console.log(`FormControl(testSearchField) value is: ${this.testForm.controls['testSearchField'].value}`);
+    console.log(`FormControl(testSpinbox) value is: ${this.testForm.controls['testSpinbox'].value}`);
+    console.log(`FormControl(testSwitch) value is: ${this.testForm.controls['testSwitch'].value}`);
+    console.log(`FormControl(testUpload) value is: ${this.testForm.controls['testUpload'].value}`);
+    console.log(`FormControl(testUploadAdvanced) value is: ${this.testForm.controls['testUploadAdvanced'].value}`);
+
+
+    document.querySelectorAll<any>('[ngDefaultControl]').forEach((input) => {
+      console.log(`${input?.name} -> value is: `, input.value);
+    });
   }
 
   public updateModel() {

--- a/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
@@ -15,6 +15,7 @@ export class ExampleComponent implements OnInit {
   ngOnInit(): void {
     this.testForm = new FormGroup({
       testCheckbox: new FormControl(),
+      testCheckboxGroup: new FormControl(),
       testDateObject: new FormControl(new Date()),
       testDateString: new FormControl('12/31/2020'),
       testDropdown: new FormControl('opt5'),
@@ -33,6 +34,7 @@ export class ExampleComponent implements OnInit {
 
   public onFormSubmit() {
     console.log(`testCheckbox selected is: ${this.testForm.controls['testCheckbox'].value}`);
+    console.log(`testCheckboxGroup selected is: ${this.testForm.controls['testCheckboxGroup'].value}`);
     console.log(`testDateObject entered is: ${this.testForm.controls['testDateObject'].value}`);
     console.log(`testDateString entered is: ${this.testForm.controls['testDateString'].value}`);
     console.log(`testDropdown selected is: ${this.testForm.controls['testDropdown'].value}`);
@@ -49,7 +51,9 @@ export class ExampleComponent implements OnInit {
   }
 
   public updateModel() {
-    this.testForm.controls['testSwitch'].setValue(!this.testForm.controls['testSwitch'].value); 
+    this.testForm.controls['testSwitch'].setValue(!this.testForm.controls['testSwitch'].value);
+    this.testForm.controls['testCheckbox'].setValue(!this.testForm.controls['testCheckbox'].value);
+    this.testForm.controls['testCheckboxGroup'].setValue(!this.testForm.controls['testCheckboxGroup'].value);
   }
 
 }

--- a/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
@@ -67,9 +67,9 @@ export class ExampleComponent implements OnInit {
     this.testForm.controls['testTimePicker'].setValue(!this.testForm.controls['testTimePicker'].value);
     this.testForm.controls['testRadio'].setValue(!this.testForm.controls['testRadio'].value);
     this.testForm.controls['testSearchField'].setValue(randomText(3));
-    this.testForm.controls['testSpinbox'].setValue(!this.testForm.controls['testSpinbox'].value);
-    this.testForm.controls['testUpload'].setValue(!this.testForm.controls['testUpload'].value);
-    this.testForm.controls['testUploadAdvanced'].setValue(!this.testForm.controls['testUploadAdvanced'].value);
+    this.testForm.controls['testSpinbox'].setValue(Math.floor(Math.random() * 100));
+    this.testForm.controls['testUpload'].setValue(`${randomText(2).split(' ').join('/')}.txt`);
+    this.testForm.controls['testUploadAdvanced'].setValue(`${randomText(3).split(' ').join('/')}.txt`);
 
     this.testForm.controls['testSwitch'].setValue(!this.testForm.controls['testSwitch'].value);
     this.testForm.controls['testCheckbox'].setValue(!this.testForm.controls['testCheckbox'].value);


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fix `ids-checkbox` and `ids-checkbox-group` so that their values are properly reflected in Angular when using `ngDefaultControl`.

**Included in this Pull Request**:

Added this code:

```javascript
  public updateModel() {
    this.testForm.controls['testSwitch'].setValue(!this.testForm.controls['testSwitch'].value);
    this.testForm.controls['testCheckbox'].setValue(!this.testForm.controls['testCheckbox'].value);
    this.testForm.controls['testCheckboxGroup'].setValue(!this.testForm.controls['testCheckboxGroup'].value);
  }
```

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
1. Go to http://localhost:4200/ids-reactive-forms/example
2. Click on the button after adding the below code
3. Lets test all fields on this form in this manner

**Expected behavior**
Should be able to update the model pragmatically. Open the browsers developer console and test the values for the checkbox and the checkbox-group after clicking the spin-box's `Update Booleans` button and the form's submit button.

**Related github/jira issue(s) (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes https://github.com/infor-design/enterprise-wc/issues/1693

