### PR TITLE
1744 - Fix IdsModal display issues in Angular

### DIFF
--- a/angular-ids-wc/src/app/components/ids-modal/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/example/example.component.html
@@ -3,7 +3,7 @@
   
   <ids-modal #modal id="my-modal" aria-labelledby="my-modal-title">
     <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
-    <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary">
+    <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary" (click)="handleHide()">
       <span>OK</span>
     </ids-modal-button>
     <ids-text align="left">This is an active IDS Modal component</ids-text>

--- a/angular-ids-wc/src/app/components/ids-modal/demos/example/example.component.ts
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/example/example.component.ts
@@ -17,4 +17,7 @@ export class ExampleComponent implements AfterViewInit {
     this.modal.nativeElement.show();
   }
 
+  handleHide() {
+    this.modal.nativeElement.hide();
+  }
 }

--- a/angular-ids-wc/src/app/components/ids-modal/demos/focus/focus.component.html
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/focus/focus.component.html
@@ -1,13 +1,23 @@
 <ids-container padding="8" hidden>
   <ids-theme-switcher mode="light"></ids-theme-switcher>
 
-  <ids-modal id="my-modal" aria-labelledby="my-modal-title">
+  <ids-modal #modal id="my-modal" aria-labelledby="my-modal-title">
     <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">IDS Focus Capture Demo</ids-text>
 
     <ids-text font-size="14">Use the <kbd>Tab</kbd> and <kbd>Shift+Tab</kbd> keystrokes to change element focus. Use the checkboxes below to change focus behavior.</ids-text>
     <br>
-    <ids-checkbox id="setting-capture" label="Capture Focus" checked></ids-checkbox>
-    <ids-checkbox id="setting-cycle" label="Cycle Focus" checked></ids-checkbox>
+    <ids-checkbox
+      #settingCaptureCheck
+      id="setting-capture"
+      label="Capture Focus"
+      checked
+      (change)="handleSettingCaptureChange($event)"></ids-checkbox>
+    <ids-checkbox
+      #settingCycleCheck
+      id="setting-cycle"
+      label="Cycle Focus"
+      checked
+      (change)="handleSettingCycleChange($event)"></ids-checkbox>
 
     <ids-modal-button slot="buttons" id="modal-cancel-btn" appearance="secondary" cancel>
       <span>Cancel</span>
@@ -22,7 +32,7 @@
   </ids-layout-grid>
   <ids-layout-grid auto-fit="true" padding="md">
     <ids-layout-grid-cell>
-      <ids-button id="modal-trigger-btn" appearance="secondary">
+      <ids-button (click)="handleShow()" id="modal-trigger-btn" appearance="secondary">
         <span>Observe Focus Capture Behavior</span>
       </ids-button>
     </ids-layout-grid-cell>

--- a/angular-ids-wc/src/app/components/ids-modal/demos/focus/focus.component.ts
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/focus/focus.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, AfterViewInit, OnInit, ViewChild, ElementRef } from '@angular/core';
 
 @Component({
   selector: 'app-focus',
@@ -6,6 +6,9 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./focus.component.css']
 })
 export class FocusComponent implements OnInit {
+  @ViewChild('modal', { read: ElementRef }) modal;
+  @ViewChild('settingCaptureCheck', { read: ElementRef }) settingCaptureCheck;
+  @ViewChild('settingCycleCheck', { read: ElementRef }) settingCycleCheck;
 
   constructor() { }
 
@@ -13,4 +16,21 @@ export class FocusComponent implements OnInit {
     console.log('focus init');
   }
 
+  handleShow() {
+    this.modal.nativeElement.show();
+  }
+
+  handleHide() {
+    this.modal.nativeElement.hide();
+  }
+
+  handleSettingCaptureChange(e: Event) {
+    console.info('change "capture focus" setting');
+    this.modal.nativeElement.capturesFocus = (e.target as any).checked;
+  }
+
+  handleSettingCycleChange(e: Event) {
+    console.info('change "cycle focus" setting');
+    this.modal.nativeElement.cyclesFocus = (e.target as any).checked;
+  }
 }

--- a/angular-ids-wc/src/app/components/ids-modal/demos/fullsize/fullsize.component.html
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/fullsize/fullsize.component.html
@@ -1,34 +1,45 @@
 <ids-container padding="8" hidden>
   <ids-theme-switcher mode="light"></ids-theme-switcher>
   
-  <ids-modal id="my-modal" aria-labelledby="my-modal-title">
+  <ids-modal #modal id="my-modal" aria-labelledby="my-modal-title" [attr.fullsize]="this.model.currentBreakpoint">
     <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
-    <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary">
+    <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary" (click)="handleHide()">
       <span>OK</span>
     </ids-modal-button>
-    <ids-text>This modal will appear fullsize when the browser viewport is below the <span id="break">"sm (600px)"</span> breakpoint.<br /><br />
+    <ids-text>This modal will appear fullsize when the browser viewport is below the <span id="break">"{{ this.model.currentBreakpoint }}"</span> breakpoint.<br /><br />
       <ids-text font-size="16">Current Window Width:</ids-text>
-      <ids-text class="current-window-width" font-size="16" font-weight="bold"></ids-text>
+      <ids-text class="current-window-width" font-size="16" font-weight="bold">{{ this.model.viewportSize }}px</ids-text>
     </ids-text>
   </ids-modal>
 
   <ids-layout-grid auto-fit="true" padding="md">
     <ids-text font-size="12" type="h1">Modal (Fullsize Setting)</ids-text>
   </ids-layout-grid>
-  <ids-layout-grid auto-fit="true" padding="md">
+  <ids-layout-grid auto-fit="true" padding-x="md">
     <ids-layout-grid-cell>
       <ids-text font-size="16">Current Window Width:</ids-text>
-      <ids-text class="current-window-width" font-size="16" font-weight="bold"></ids-text>
+      <ids-text class="current-window-width" font-size="16" font-weight="bold">{{ this.model.viewportSize }}px</ids-text>
     </ids-layout-grid-cell>
   </ids-layout-grid>
   <ids-layout-grid auto-fit="true" padding="md">
     <ids-layout-grid-cell>
-      <ids-radio-group id="sizes" label="IdsModal will become fullsize when the browser viewport is below the selected breakpoint:"></ids-radio-group>
+      <ids-radio-group 
+        id="sizes" 
+        label="IdsModal will become fullsize when the browser viewport is below the selected breakpoint:"
+        [ngModel]="this.model.currentBreakpoint">
+        <ids-radio
+          *ngFor="let option of this.model.breakpoints"
+          checked="{{option.checked}}"
+          label="{{option.text}}"
+          value="{{option.value}}"
+          [ngModel]="this.model.breakpoints"
+          (change)="onRadioChange($event)"></ids-radio>
+      </ids-radio-group>
     </ids-layout-grid-cell>
   </ids-layout-grid>
   <ids-layout-grid auto-fit="true" padding="md">
     <ids-layout-grid-cell>
-      <ids-button id="modal-trigger-btn" appearance="secondary">
+      <ids-button id="modal-trigger-btn" appearance="secondary" (click)="handleShow()">
         <span>Trigger a Modal</span>
       </ids-button>
     </ids-layout-grid-cell>

--- a/angular-ids-wc/src/app/components/ids-modal/demos/fullsize/fullsize.component.ts
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/fullsize/fullsize.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef, NgZone } from '@angular/core';
+import { breakpoints } from 'ids-enterprise-wc/utils/ids-breakpoint-utils/ids-breakpoint-utils';
 
 @Component({
   selector: 'app-fullsize',
@@ -6,11 +7,86 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./fullsize.component.css']
 })
 export class FullsizeComponent implements OnInit {
+  @ViewChild('modal', { read: ElementRef }) modal;
 
-  constructor() { }
+  constructor(
+    private host: ElementRef,
+    private zone: NgZone
+  ) { }
+
+  public model = {
+    breakpoints: [],
+    currentBreakpoint: null,
+    viewportSize: 0
+  };
+
+  /**
+   * Creates selectable radio items representing available IDS breakpoints
+   * (draws from IdsBreakpointUtils)
+   */
+  private defineBreakpoints() {
+    const fullsizeValues: Array<string | null> = [null, ...Object.keys(breakpoints).reverse(), 'always'];
+    const radioDefs = [];
+
+    fullsizeValues.forEach((val, i) => {
+      const checked = i < 1;
+      let text = val;
+      let size = '';
+
+      if (val !== null && val !== 'always') {
+        size = breakpoints[val];
+      }
+      if (val === null) {
+        text = 'Never';
+      }
+      if (val === 'always') {
+        text = 'Always';
+        size = 'always'
+      }
+      if (size.length) {
+        text += ` (${size})`;
+      }
+
+      radioDefs.push({
+        checked, 
+        size, 
+        text, 
+        value: val
+      })
+    });
+
+    this.model.breakpoints = radioDefs;
+  }
+
+  /**
+   * Resize Observer for displaying current window width
+   */
+  private observeViewportSize() {
+    // note: ResizeObserver updates MUST run inside NgZone
+    // @see https://dev.to/christiankohler/how-to-use-resizeobserver-with-angular-9l5#3-trigger-change-detection
+    const ro = new ResizeObserver(() => {
+      this.zone.run(() => {
+        this.model.viewportSize = window.innerWidth;
+      })
+    });
+    ro.observe(document.querySelector('body') as any);
+  }
 
   ngOnInit(): void {
     console.log('fullsize init');
+    this.defineBreakpoints();
+    this.observeViewportSize();
   }
 
+  handleShow() {
+    this.modal.nativeElement.show();
+  }
+
+  handleHide() {
+    this.modal.nativeElement.hide();
+  }
+
+  onRadioChange(e: CustomEvent) {
+    this.model.currentBreakpoint = e.detail.value;
+  }
 }

--- a/angular-ids-wc/src/app/components/ids-modal/demos/keep-open/keep-open.component.html
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/keep-open/keep-open.component.html
@@ -1,14 +1,18 @@
 <ids-container padding="8" hidden>
   <ids-theme-switcher mode="light"></ids-theme-switcher>
   
-  <ids-modal id="my-modal" aria-labelledby="my-modal-title">
+  <ids-modal #modal id="my-modal" aria-labelledby="my-modal-title">
     <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
-    <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary">
+    <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary" (click)="handleHide()">
       <span>OK</span>
     </ids-modal-button>
     <ids-text>The checkbox below controls whether or not a user can click in the overlay to close this Modal</ids-text>
     <br>
-    <ids-checkbox label="Allow the modal to close by clicking outside" checked></ids-checkbox>
+    <ids-checkbox
+      #clickOutsideCheck 
+      label="Allow the modal to close by clicking outside" 
+      checked
+      (change)="handleClickOutsideChange($event)"></ids-checkbox>
   </ids-modal>
 
   <ids-layout-grid auto-fit="true" padding="md">
@@ -16,7 +20,7 @@
   </ids-layout-grid>
   <ids-layout-grid auto-fit="true" padding="md">
     <ids-layout-grid-cell>
-      <ids-button id="modal-trigger-btn" appearance="secondary">
+      <ids-button id="modal-trigger-btn" appearance="secondary" (click)="handleShow()">
         <span>Trigger a Modal</span>
       </ids-button>
     </ids-layout-grid-cell>

--- a/angular-ids-wc/src/app/components/ids-modal/demos/keep-open/keep-open.component.ts
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/keep-open/keep-open.component.ts
@@ -1,11 +1,15 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, AfterViewInit, OnInit, ViewChild, ElementRef } from '@angular/core';
 
 @Component({
   selector: 'app-keep-open',
   templateUrl: './keep-open.component.html',
   styleUrls: ['./keep-open.component.css']
 })
-export class KeepOpenComponent implements OnInit {
+export class KeepOpenComponent implements OnInit, AfterViewInit {
+  @ViewChild('modal', { read: ElementRef }) modal;
+  @ViewChild('closeOutsideCheck', { read: ElementRef }) closeOutsideCheck;
+
+  private defaultOnOutsideClick;
 
   constructor() { }
 
@@ -13,4 +17,25 @@ export class KeepOpenComponent implements OnInit {
     console.log('keep-open init');
   }
 
+  ngAfterViewInit(): void {
+    this.defaultOnOutsideClick = this.modal.nativeElement.onOutsideClick;
+  }
+
+  handleShow() {
+    this.modal.nativeElement.show();
+  }
+
+  handleHide() {
+    this.modal.nativeElement.hide();
+  }
+
+  handleClickOutsideChange(e: Event) {
+    const isChecked = (e.target as any).checked;
+    if (isChecked) {
+      this.modal.nativeElement.onOutsideClick = this.defaultOnOutsideClick;
+    } else {
+      // Overrides the default `onOutsideClick` to just keep the Modal open
+      this.modal.nativeElement.onOutsideClick = () => { };
+    }
+  }
 }

--- a/angular-ids-wc/src/app/components/ids-modal/demos/nested/nested.component.html
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/nested/nested.component.html
@@ -1,21 +1,21 @@
 <ids-container padding="8" hidden>
   <ids-theme-switcher mode="light"></ids-theme-switcher>
   
-  <ids-modal id="parent-modal" aria-labelledby="parent-modal-title">
+  <ids-modal #parentModal id="parent-modal" aria-labelledby="parent-modal-title">
     <ids-text slot="title" font-size="24" type="h2" id="parent-modal-title">Parent Modal</ids-text>
     <ids-text>This is the Parent IDS Modal</ids-text><br>
-    <ids-modal-button slot="buttons" id="parent-modal-close-btn" appearance="secondary" cancel>
+    <ids-modal-button slot="buttons" id="parent-modal-close-btn" appearance="secondary" (click)="handleParentHide()">
       <span>Close</span>
     </ids-modal-button>
-    <ids-modal-button slot="buttons" id="nested-modal-trigger-btn" appearance="primary">
+    <ids-modal-button slot="buttons" id="nested-modal-trigger-btn" appearance="primary" (click)="handleNestedShow()">
       <span>Open Another</span>
     </ids-modal-button>
   </ids-modal>
 
-  <ids-modal id="nested-modal" aria-labelledby="nested-modal-title">
+  <ids-modal #nestedModal id="nested-modal" aria-labelledby="nested-modal-title">
     <ids-text slot="title" font-size="24" type="h2" id="nested-modal-title">Nested Modal</ids-text>
     <ids-text>This is the Nested IDS Modal</ids-text><br>
-    <ids-modal-button slot="buttons" id="nested-modal-close-btn" appearance="secondary" cancel>
+    <ids-modal-button slot="buttons" id="nested-modal-close-btn" appearance="secondary" (click)="handleNestedHide()">
       <span>Close</span>
     </ids-modal-button>
   </ids-modal>
@@ -25,7 +25,7 @@
   </ids-layout-grid>
   <ids-layout-grid auto-fit="true" padding="md">
     <ids-layout-grid-cell>
-      <ids-button id="parent-modal-trigger-btn" appearance="secondary">
+      <ids-button id="parent-modal-trigger-btn" appearance="secondary" (click)="handleParentShow()">
         <span>Trigger a Modal</span>
       </ids-button>
     </ids-layout-grid-cell>

--- a/angular-ids-wc/src/app/components/ids-modal/demos/nested/nested.component.ts
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/nested/nested.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, AfterViewInit, OnInit, ViewChild, ElementRef } from '@angular/core';
 
 @Component({
   selector: 'app-nested',
@@ -6,11 +6,29 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./nested.component.css']
 })
 export class NestedComponent implements OnInit {
+  @ViewChild('parentModal', { read: ElementRef }) parentModal;
+  @ViewChild('nestedModal', { read: ElementRef }) nestedModal;
 
   constructor() { }
 
   ngOnInit(): void {
     console.log('nested init');
+  }
+
+  handleParentShow() {
+    this.parentModal.nativeElement.show();
+  }
+
+  handleParentHide() {
+    this.parentModal.nativeElement.hide();
+  }
+
+  handleNestedShow() {
+    this.nestedModal.nativeElement.show();
+  }
+
+  handleNestedHide() {
+    this.nestedModal.nativeElement.hide();
   }
 
 }

--- a/angular-ids-wc/src/app/components/ids-modal/demos/visible/visible.component.html
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/visible/visible.component.html
@@ -1,7 +1,7 @@
 <ids-container padding="8" hidden>
   <ids-theme-switcher mode="light"></ids-theme-switcher>
   
-  <ids-modal id="my-modal" visible="true" aria-labelledby="my-modal-title">
+  <ids-modal #modal id="my-modal" visible="true" aria-labelledby="my-modal-title">
     <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
     <ids-text>This is an active IDS Modal component</ids-text>
     <ids-modal-button slot="buttons" id="modal-close-btn" appearance="secondary" cancel>
@@ -17,7 +17,7 @@
   </ids-layout-grid>
   <ids-layout-grid auto-fit="true" padding="md">
     <ids-layout-grid-cell>
-      <ids-button id="modal-trigger-btn" appearance="secondary">
+      <ids-button id="modal-trigger-btn" appearance="secondary" (click)="handleShow()">
         <span>Trigger a Modal</span>
       </ids-button>
     </ids-layout-grid-cell>

--- a/angular-ids-wc/src/app/components/ids-modal/demos/visible/visible.component.ts
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/visible/visible.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, AfterViewInit, OnInit, ViewChild, ElementRef } from '@angular/core';
 
 @Component({
   selector: 'app-visible',
@@ -6,11 +6,20 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./visible.component.css']
 })
 export class VisibleComponent implements OnInit {
+  @ViewChild('modal', { read: ElementRef }) modal;
 
   constructor() { }
 
   ngOnInit(): void {
     console.log('visible init');
+  }
+
+  handleShow() {
+    this.modal.nativeElement.show();
+  }
+
+  handleHide() {
+    this.modal.nativeElement.hide();
   }
 
 }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
This PR makes some changes to better adopt IdsModal in its examples, and makes some non-functional examples work properly:
- All examples no longer displays a "broken" modal on page load
- All examples now mimic their WC library counterparts (for example, Focus capture/cycle settings example works properly)

**Related github/jira issue(s) (required)**:
Closes infor-design/enterprise-wc#1744

**Steps necessary to review your pull request (required)**:
- Pull the related enterprise branch from infor-design/enterprise-wc#1749
- Use `npm run publish:link` on this PR to install as a local NPM package, and use `npm link ids-enterprise-wc` in this project to link
- Run `npm start`
- Open http://localhost:4200/ids-modal/example
- When this example loads, it should not display unwrapped modal content
- Open http://localhost:4200/ids-modal/fullsize
- Show the modal at different breakpoints to make sure different sizes work
- Open http://localhost:4200/ids-modal/focus
- Open the modal and try unchecking each/both boxes.  They should have an effect on the modal's focus settings
- Open http://localhost:4200/ids-modal/nested
- Both modals (parent and nested) should open and close properly