### PR TITLE
1670 - ids-lookup apply button not hiding in angular

### DIFF
--- a/angular-ids-wc/src/app/components/ids-lookup/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-lookup/demos/example/example.component.html
@@ -21,16 +21,16 @@
 
       <!-- <ids-lookup id="lookup-2" readonly="true" label="Readonly Lookup" value="102"></ids-lookup>
       <ids-lookup id="lookup-3" disabled="true" label="Disabled Lookup" value="103"></ids-lookup>
-      <ids-lookup id="lookup-4" label="Required Lookup" validate="required"></ids-lookup>
+      <ids-lookup id="lookup-4" label="Required Lookup" validate="required"></ids-lookup> -->
       <ids-lookup id="lookup-5" label="Custom Lookup">
         <ids-modal slot="lookup-modal" id="custom-lookup-modal" aria-labelledby="custom-lookup-modal-title">
           <ids-text slot="title" font-size="24" type="h2" id="lookup-modal-title">Custom Lookup Modal</ids-text>
-          <ids-modal-button slot="buttons" id="modal-cancel-btn" appearance="primary">
+          <ids-modal-button confirm slot="buttons" appearance="primary">
             <span>Apply</span>
           </ids-modal-button>
         </ids-modal>
       </ids-lookup>
-      <ids-lookup
+      <!-- <ids-lookup
         id="lookup-6"
         label="Autocomplete Lookup"
         title="Select an Item"


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
When clicking the modal "apply" button on `ids-lookup` modal the modal does not hide (the pop up remains in the display state).


**Related github/jira issue(s) (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes https://github.com/infor-design/enterprise-wc/issues/1670

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Check out this branch and run: `nvm use && npm i && npm run start`
- Go to: http://localhost:4200/ids-lookup/example
- Click the search icon on the "Custom Modal" lookup to open the modal.
- Ensure the "apply" button closes the modal

