### PR TITLE
2325 - Modal Add string interpolation for modal title to angular modal examples

### DIFF
--- a/angular-ids-wc/src/app/components/ids-modal/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-modal/demos/example/example.component.html
@@ -1,8 +1,8 @@
 <ids-container padding="8" hidden>
   <ids-theme-switcher mode="light"></ids-theme-switcher>
-  
+
   <ids-modal #modal id="my-modal" aria-labelledby="my-modal-title">
-    <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">Active IDS Modal</ids-text>
+    <ids-text slot="title" font-size="24" type="h2" id="my-modal-title">{{ 'Active IDS Modal' }}</ids-text>
     <ids-modal-button slot="buttons" id="modal-close-btn" appearance="primary" (click)="handleHide()">
       <span>OK</span>
     </ids-modal-button>


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Added string interpolation for modal title to angular example to showcase the fix for the issue https://github.com/infor-design/enterprise-wc/issues/2325

**Related github/jira issue(s) (required)**:
Related https://github.com/infor-design/enterprise-wc/issues/2325