### PR TITLE
2311 - IdsListView Angular example dynamic ids-list-view-item disabled

### DIFF
--- a/angular-ids-wc/src/app/components/ids-list-view/demos/list-view-items/list-view-items.component.html
+++ b/angular-ids-wc/src/app/components/ids-list-view/demos/list-view-items/list-view-items.component.html
@@ -1,0 +1,21 @@
+<ids-container padding="8" hidden>
+  <ids-theme-switcher mode="light"></ids-theme-switcher>
+
+  <ids-layout-grid auto-fit="true" padding="md">
+    <ids-text font-size="12" type="h1">List View - Items</ids-text>
+  </ids-layout-grid>
+
+  <ids-layout-grid cols="2" gap="xl">
+    <ids-layout-grid-cell col-span="1">
+      <div class="parent-container">
+        <ids-list-view selectable="single" item-height="76">
+          <ids-list-view-item *ngFor="let item of items" (click)="onRowClick(item)" [disabled]="item.itemType === itemDisable">
+            <ids-text font-size="16" type="h2">{{item.id}} Column</ids-text>
+            <ids-text font-size="12" type="span">ID: {{item.id}}</ids-text>
+            <ids-text font-size="12" type="span">Comments: {{item.comments}}</ids-text>
+          </ids-list-view-item>
+        </ids-list-view>
+      </div>
+    </ids-layout-grid-cell>
+  </ids-layout-grid>
+</ids-container>

--- a/angular-ids-wc/src/app/components/ids-list-view/demos/list-view-items/list-view-items.component.ts
+++ b/angular-ids-wc/src/app/components/ids-list-view/demos/list-view-items/list-view-items.component.ts
@@ -1,0 +1,39 @@
+import { Component, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
+
+@Component({
+  selector: 'app-list-view-items',
+  templateUrl: './list-view-items.component.html',
+  styleUrls: ['./list-view-items.component.css']
+})
+export class ListViewItemsComponent implements AfterViewInit {
+  itemDisable = null;
+  items = [
+    { itemType: 'type1', id: 1, comments: 'One' },
+    { itemType: 'type2', id: 2, comments: 'Two' },
+    { itemType: 'type3', id: 3, comments: 'Three' },
+    { itemType: 'type4', id: 4, comments: 'Four' },
+    { itemType: 'type5', id: 5, comments: 'Five' },
+    { itemType: 'type6', id: 6, comments: 'Six' },
+    { itemType: 'type7', id: 7, comments: 'Seven' },
+    { itemType: 'type8', id: 8, comments: 'Eight' },
+    { itemType: 'type9', id: 9, comments: 'Nine' },
+    { itemType: 'type10', id: 10, comments: 'Ten' },
+    { itemType: 'type11', id: 11, comments: 'Eleven' },
+    { itemType: 'type12', id: 12, comments: 'Twelve' },
+    { itemType: 'type13', id: 13, comments: 'Thirteen' },
+    { itemType: 'type14', id: 14, comments: 'Fourteen' },
+    { itemType: 'type15', id: 15, comments: 'Fifteen' },
+    { itemType: 'type16', id: 16, comments: 'Sixteen' },
+    { itemType: 'type17', id: 17, comments: 'Seventeen' },
+    { itemType: 'type18', id: 18, comments: 'Eighteen' }
+  ];
+
+  constructor() { }
+
+  ngAfterViewInit(): void {
+  }
+
+  onRowClick(item) {
+    this.itemDisable = item.itemType;
+  }
+}

--- a/angular-ids-wc/src/app/components/ids-list-view/ids-list-view-routing.module.ts
+++ b/angular-ids-wc/src/app/components/ids-list-view/ids-list-view-routing.module.ts
@@ -6,27 +6,32 @@ import { ExampleComponent } from './demos/example/example.component';
 import { SelectableSingleComponent } from './demos/selectable-single/selectable-single.component';
 import { SelectableMultipleComponent } from './demos/selectable-multiple/selectable-multiple.component';
 import { TooltipOverflowEllipsesComponent } from './demos/tooltip-overflow-ellipses/tooltip-overflow-ellipses.component';
+import { ListViewItemsComponent } from './demos/list-view-items/list-view-items.component';
 
 export const routes: Routes = [
-  { 
+  {
     path: '',
-    component: IdsListViewComponent 
+    component: IdsListViewComponent
   },
-  { 
+  {
     path: 'example',
     component: ExampleComponent
   },
-  { 
+  {
     path: 'selectable-single',
     component: SelectableSingleComponent
   },
-  { 
+  {
     path: 'selectable-multiple',
     component: SelectableMultipleComponent
   },
-  { 
+  {
     path: 'tooltip-overflow-ellipses',
     component: TooltipOverflowEllipsesComponent
+  },
+  {
+    path: 'list-view-items',
+    component: ListViewItemsComponent
   }
 ];
 

--- a/angular-ids-wc/src/app/components/ids-list-view/ids-list-view.module.ts
+++ b/angular-ids-wc/src/app/components/ids-list-view/ids-list-view.module.ts
@@ -6,9 +6,9 @@ import { IdsListViewComponent } from './ids-list-view.component';
 import { ExampleComponent } from './demos/example/example.component';
 import { SelectableSingleComponent } from './demos/selectable-single/selectable-single.component';
 import { SelectableMultipleComponent } from './demos/selectable-multiple/selectable-multiple.component';
+import { ListViewItemsComponent } from './demos/list-view-items/list-view-items.component';
 import { TooltipOverflowEllipsesComponent } from './demos/tooltip-overflow-ellipses/tooltip-overflow-ellipses.component';
 import { DemoListingModule } from '../demo-listing/demo-listing.module';
-
 
 @NgModule({
   declarations: [
@@ -16,6 +16,7 @@ import { DemoListingModule } from '../demo-listing/demo-listing.module';
     ExampleComponent,
     SelectableSingleComponent,
     SelectableMultipleComponent,
+    ListViewItemsComponent,
     TooltipOverflowEllipsesComponent
   ],
   imports: [


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Added dynamic disabled ids-list-view-item attribute example to Angular examples

**Related github/jira issue(s) (required)**:
Closes https://github.com/infor-design/enterprise-wc/issues/2311

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4200/ids-list-view/list-view-items
- click on a list item
- see it becomes disabled
- click on another list item
- see the previous one is active and the one is disabled
