### PR TITLE
splitter initialization issue

### DIFF
--- a/angular-ids-wc/src/app/app-routing.module.ts
+++ b/angular-ids-wc/src/app/app-routing.module.ts
@@ -110,6 +110,15 @@ export const routes: Routes = [
       description: 'Util for masking input'
     },
   },
+  {
+    path: 'ids-splitter',
+    loadChildren: () => import('./components/ids-splitter/ids-splitter.module').then(m => m.IdsSplitterModule),
+    data: {
+      title: 'Splitter',
+      category: 'Layouts',
+      description: 'Split Content Panes'
+    }
+  },
   { 
     path: 'ids-swaplist', 
     loadChildren: () => import('./components/ids-swaplist/ids-swaplist.module').then(m => m.IdsSwaplistModule),

--- a/angular-ids-wc/src/app/components/ids-splitter/demos/init-issue/init-issue.component.css
+++ b/angular-ids-wc/src/app/components/ids-splitter/demos/init-issue/init-issue.component.css
@@ -1,0 +1,17 @@
+.demo-splitter {
+  width: 100%;
+  height: 200px;
+}
+
+ids-container::part(container) {
+  padding: 0;
+}
+
+ids-splitter-pane:first-child {
+  padding: 8px;
+}
+
+ids-splitter-pane:last-child {
+  white-space: normal;
+  padding: 8px;
+}

--- a/angular-ids-wc/src/app/components/ids-splitter/demos/init-issue/init-issue.component.html
+++ b/angular-ids-wc/src/app/components/ids-splitter/demos/init-issue/init-issue.component.html
@@ -1,0 +1,17 @@
+<ids-container role="main" padding="8" hidden>
+  <ids-theme-switcher mode="light"></ids-theme-switcher>
+  <ids-layout-grid auto-fit="true" padding="md">
+    <ids-text font-size="12" type="h1">Splitter</ids-text>
+  </ids-layout-grid>
+
+  <div class="demo-splitter">
+    <ids-splitter #IdsSplitter>
+      <ids-splitter-pane id="splitter-left" size="30%">
+        <ids-text type="p">left pane</ids-text>
+      </ids-splitter-pane>
+      <ids-splitter-pane id="splitter-right">
+        <ids-text type="p">right pane</ids-text>
+      </ids-splitter-pane>
+    </ids-splitter>
+  </div>
+</ids-container>

--- a/angular-ids-wc/src/app/components/ids-splitter/demos/init-issue/init-issue.component.ts
+++ b/angular-ids-wc/src/app/components/ids-splitter/demos/init-issue/init-issue.component.ts
@@ -1,0 +1,26 @@
+import { Component, AfterViewInit, ElementRef, ViewChild } from '@angular/core';
+import 'ids-enterprise-wc/components/ids-splitter/ids-splitter';
+import IdsSplitter, { IdsSplitterCollapseExpandOpts } from 'ids-enterprise-wc/components/ids-splitter/ids-splitter';
+
+@Component({
+  selector: 'app-init-issue-splitter',
+  templateUrl: './init-issue.component.html',
+  styleUrls: ['./init-issue.component.css']
+})
+export class InitIssueComponent implements AfterViewInit {
+  @ViewChild('IdsSplitter') idsSplitterRef: ElementRef;
+  private idsSplitter: IdsSplitter;
+
+  private readonly idsSplitterCollapseExpandOpts: IdsSplitterCollapseExpandOpts = {
+    startPane: '#splitter-left',
+    endPane: '#splitter-right',
+  };
+
+  constructor() { }
+
+  ngAfterViewInit(): void {
+    console.log('IdsSplitter AfterViewInit');
+    this.idsSplitter = this.idsSplitterRef.nativeElement;
+    this.idsSplitter.collapse(this.idsSplitterCollapseExpandOpts)
+  }
+}

--- a/angular-ids-wc/src/app/components/ids-splitter/ids-splitter-routing.module.ts
+++ b/angular-ids-wc/src/app/components/ids-splitter/ids-splitter-routing.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { InitIssueComponent } from './demos/init-issue/init-issue.component';
+import { IdsSplitterComponent } from './ids-splitter.component';
+
+export const routes: Routes = [
+  {
+    path: '',
+    component: IdsSplitterComponent
+  },
+  {
+    path: 'init-issue',
+    component: InitIssueComponent
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class IdsSplitterRoutingModule { }

--- a/angular-ids-wc/src/app/components/ids-splitter/ids-splitter.component.html
+++ b/angular-ids-wc/src/app/components/ids-splitter/ids-splitter.component.html
@@ -1,0 +1,1 @@
+<app-demo-listing [title]="'Ids Splitter Examples'" [routes]="routes"></app-demo-listing>

--- a/angular-ids-wc/src/app/components/ids-splitter/ids-splitter.component.ts
+++ b/angular-ids-wc/src/app/components/ids-splitter/ids-splitter.component.ts
@@ -1,0 +1,18 @@
+import { Component, AfterViewInit } from '@angular/core';
+import { routes } from './ids-splitter-routing.module';
+
+@Component({
+  selector: 'app-ids-splitter',
+  templateUrl: './ids-splitter.component.html',
+  styleUrls: ['./ids-splitter.component.css']
+})
+export class IdsSplitterComponent implements AfterViewInit {
+  public routes = routes.filter(r => r.path !== '');
+
+  constructor() { }
+
+  ngAfterViewInit(): void {
+    console.log('IdsSplitter AfterViewInit');
+  }
+
+}

--- a/angular-ids-wc/src/app/components/ids-splitter/ids-splitter.module.ts
+++ b/angular-ids-wc/src/app/components/ids-splitter/ids-splitter.module.ts
@@ -1,0 +1,22 @@
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DemoListingModule } from './../demo-listing/demo-listing.module';
+
+import { IdsSplitterRoutingModule } from './ids-splitter-routing.module';
+import { IdsSplitterComponent } from './ids-splitter.component';
+import { InitIssueComponent } from './demos/init-issue/init-issue.component';
+
+
+@NgModule({
+  declarations: [
+    IdsSplitterComponent,
+    InitIssueComponent
+  ],
+  imports: [
+    CommonModule,
+    IdsSplitterRoutingModule,
+    DemoListingModule
+  ],
+  schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+})
+export class IdsSplitterModule { }


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Want to be able to call a collapse function initially in an ids-splitter but the component is not ready when calling idsSplitter collapse() from in ngAfterViewInit

**Related github/jira issue(s) (required)**:

Closes https://github.com/infor-design/enterprise-wc/issues/2581

**Steps necessary to review your pull request (required)**:
- run angular-ids-wc 
- In web open splitter
- click on init-issue
Notice the left split pane is NOT collapsed

There is also an error in the console complaining that a parentNode is null.

**Included in this Pull Request**:
- [ ] Added ids splitter examples
