### PR TITLE
2432 - Add multiselect typeahead to Angular examples

### DIFF
--- a/angular-ids-wc/src/app/components/ids-multiselect/demos/typeahead/typeahead.component.html
+++ b/angular-ids-wc/src/app/components/ids-multiselect/demos/typeahead/typeahead.component.html
@@ -1,0 +1,66 @@
+<ids-container padding="8" hidden>
+  <ids-theme-switcher mode="light"></ids-theme-switcher>
+
+  <ids-layout-grid auto-fit="true" padding="md">
+    <ids-text font-size="12" type="h1">Multiselect Typeahead</ids-text>
+  </ids-layout-grid>
+
+  <ids-layout-grid auto-fit="true" padding="md">
+    <ids-layout-grid-cell>
+      <ids-multiselect #idsMultiselect typeahead id="multiselect-2" label="Test Multiselect (max choices 3)" max="3">
+        <ids-list-box>
+          <ids-list-box-option class="multiselect-option" id="al2" value="al" tooltip="The State of Alabama"><ids-checkbox no-margin label="Alabama" class="justify-center"></ids-checkbox></ids-list-box-option>
+          <ids-list-box-option class="multiselect-option" id="ak2" value="ak" tooltip="The State of Alaska"><ids-checkbox no-margin label="Alaska" class="justify-center"></ids-checkbox></ids-list-box-option>
+          <ids-list-box-option class="multiselect-option" id="az2" value="az" tooltip="The State of Arizona"><ids-checkbox no-margin label="Arizona" class="justify-center"></ids-checkbox></ids-list-box-option>
+          <ids-list-box-option class="multiselect-option" id="ar2" value="ar" tooltip="The State of Arkansas"><ids-checkbox no-margin label="Arkansas" class="justify-center"></ids-checkbox></ids-list-box-option>
+          <ids-list-box-option class="multiselect-option" id="ca2" value="ca" tooltip="The State of California"><ids-checkbox no-margin label="California" class="justify-center"></ids-checkbox></ids-list-box-option>
+          <ids-list-box-option class="multiselect-option" id="co2" value="co" tooltip="The State of Colorado"><ids-checkbox no-margin label="Colorado" class="justify-center"></ids-checkbox></ids-list-box-option>
+          <ids-list-box-option class="multiselect-option" id="nj2" value="nj" tooltip="The State of New Jersey" selected><ids-checkbox no-margin checked="true" label="New Jersey" class="justify-center"></ids-checkbox></ids-list-box-option>
+        </ids-list-box>
+      </ids-multiselect>
+
+      <ids-multiselect #idsMultiselect typeahead id="multiselect-3" label="Test Multiselect (with icons)" max="3" tags="true">
+        <ids-list-box>
+          <ids-list-box-option value="opt1" id="opt1-d5">
+            <ids-icon icon="user-profile"></ids-icon>
+            <span>Option One</span>
+          </ids-list-box-option>
+          <ids-list-box-option value="opt2" id="opt2-d5">
+            <ids-icon icon="project"></ids-icon>
+            <span>Option Two</span>
+          </ids-list-box-option>
+          <ids-list-box-option value="opt3" id="opt3-d5">
+            <ids-icon icon="purchasing"></ids-icon>
+            <span>Option Three</span>
+          </ids-list-box-option>
+          <ids-list-box-option value="opt4" id="opt4-d5">
+            <ids-icon icon="quality"></ids-icon>
+            <span>Option Four</span></ids-list-box-option>
+          <ids-list-box-option value="opt5" id="opt5-d5">
+            <ids-icon icon="rocket"></ids-icon>
+            <span>Option Five</span>
+          </ids-list-box-option>
+          <ids-list-box-option value="opt6" id="opt6-d5">
+            <ids-icon icon="roles"></ids-icon>
+            <span>Option Six</span>
+          </ids-list-box-option>
+        </ids-list-box>
+      </ids-multiselect>
+
+      <ids-multiselect #idsMultiselect typeahead id="multiselect-4" tags="true" label="Test Multiselect (using ngFor)" max="10">
+        <ids-list-box>
+          <ng-container *ngFor="let option of coldStates.concat(hotStates); index as i">
+            <ids-list-box-option
+              class="multiselect-option"
+              [id]="option.id"
+              [value]="option.value"
+              [tooltip]="option.tooltip"
+            >
+              <ids-checkbox no-margin [label]="option.label" class="justify-center"></ids-checkbox>
+            </ids-list-box-option>
+          </ng-container>
+        </ids-list-box>
+      </ids-multiselect>
+    </ids-layout-grid-cell>
+  </ids-layout-grid>
+</ids-container>

--- a/angular-ids-wc/src/app/components/ids-multiselect/demos/typeahead/typeahead.component.ts
+++ b/angular-ids-wc/src/app/components/ids-multiselect/demos/typeahead/typeahead.component.ts
@@ -1,0 +1,46 @@
+import { Component, AfterViewInit, ViewChildren, QueryList, ElementRef } from '@angular/core';
+
+@Component({
+  selector: 'app-typeahead-multiselect',
+  templateUrl: './typeahead.component.html',
+  styleUrls: ['./typeahead.component.css']
+})
+export class ExampleTypeaheadComponent implements AfterViewInit {
+  @ViewChildren('idsMultiselect') multiselects: QueryList<ElementRef>;
+
+  coldStates = [
+    { id: "ak2", value: "ak", tooltip: "The State of Alaska", label: "Alaska" },
+    { id: "me2", value: "me", tooltip: "The State of Maine", label: "Maine" },
+    { id: "mt2", value: "mt", tooltip: "The State of Montana", label: "Montana" },
+  ];
+
+  hotStates = [
+    { id: "ca2", value: "ca", tooltip: "The State of California", label: "California" },
+    { id: "fl2", value: "fl", tooltip: "The State of Florida", label: "Florida" },
+    { id: "tx2", value: "tx", tooltip: "The State of Texas", label: "Texas" },
+  ];
+
+  private isInitialized = false;
+
+  constructor() { }
+
+  ngAfterViewInit(): void {
+    this.multiselects.forEach((multiselect: ElementRef) => {
+      const element = multiselect.nativeElement;
+      element.addEventListener('change', this.onChangeEvent.bind(this));
+    });
+
+    setTimeout(() => {
+      this.isInitialized = true;
+    });
+  }
+
+  onChangeEvent(e: any): void {
+    if (!this.isInitialized) {
+      return;
+    }
+
+    console.info(`e.target.selectedOptions`, e.target?.selectedOptions);
+    console.info(`Value Changed to :`, e.target.value, e.detail.value);
+  }
+}

--- a/angular-ids-wc/src/app/components/ids-multiselect/ids-multiselect-routing.module.ts
+++ b/angular-ids-wc/src/app/components/ids-multiselect/ids-multiselect-routing.module.ts
@@ -3,15 +3,20 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { IdsMultiselectComponent } from './ids-multiselect.component';
 import { ExampleComponent } from './demos/example/example.component';
+import { ExampleTypeaheadComponent } from './demos/typeahead/typeahead.component';
 
 export const routes: Routes = [
-  { 
-    path: '', 
+  {
+    path: '',
     component: IdsMultiselectComponent,
   },
-  { 
+  {
     path: 'example',
     component: ExampleComponent,
+  },
+  {
+    path: 'typeahead',
+    component: ExampleTypeaheadComponent,
   }
 ];
 

--- a/angular-ids-wc/src/app/components/ids-multiselect/ids-multiselect.module.ts
+++ b/angular-ids-wc/src/app/components/ids-multiselect/ids-multiselect.module.ts
@@ -5,12 +5,13 @@ import { IdsMultiselectRoutingModule } from './ids-multiselect-routing.module';
 import { IdsMultiselectComponent } from './ids-multiselect.component';
 import { ExampleComponent } from './demos/example/example.component';
 import { DemoListingModule } from '../demo-listing/demo-listing.module';
-
+import { ExampleTypeaheadComponent } from './demos/typeahead/typeahead.component';
 
 @NgModule({
   declarations: [
     IdsMultiselectComponent,
     ExampleComponent,
+    ExampleTypeaheadComponent,
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Added multiselect typeahead examples to Angular

**Related github/jira issue(s) (required)**:
Related https://github.com/infor-design/enterprise-wc/issues/1867

**Steps necessary to review your pull request (required)**:
- pull and build Angular examples
- go to http://localhost:4200/ids-multiselect/typeahead
- check if input value filters dropdown options in tags and non tags examples

