### PR TITLE
2700 - IdsRadio Add form control/value binding Angular example

### DIFF
--- a/angular-ids-wc/src/app/components/ids-reactive-forms/demos/form-control/form-control.component.html
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/demos/form-control/form-control.component.html
@@ -1,0 +1,16 @@
+<ids-container padding="8" hidden>
+  <ids-theme-switcher mode="light"></ids-theme-switcher>
+
+  <ids-layout-grid cols="3" gap="md" padding="md">
+    <ids-text font-size="12" type="h1">FormControl and value binding</ids-text>
+  </ids-layout-grid>
+  <ids-layout-grid cols="3" gap="md" padding-x="md">
+    <ids-layout-grid-cell>
+      <ids-radio-group label="IDS Radio Group (radio two should be checked)" [formControl]="testRadio" ngDefaultControl>
+        <ids-radio [value]="radio1" label="radio one"></ids-radio>
+        <ids-radio [value]="radio2" label="radio two"></ids-radio>
+        <ids-radio [value]="radio3" label="radio three"></ids-radio>
+      </ids-radio-group>
+    </ids-layout-grid-cell>
+  </ids-layout-grid>
+</ids-container>

--- a/angular-ids-wc/src/app/components/ids-reactive-forms/demos/form-control/form-control.component.ts
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/demos/form-control/form-control.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { FormControl } from '@angular/forms';
+
+@Component({
+  selector: 'app-reactive-form-control',
+  templateUrl: './form-control.component.html',
+  styleUrls: ['./form-control.component.css'],
+})
+export class FormControlComponent {
+  radio1 = 'radio1';
+  radio2 = 'radio2';
+  radio3 = 'radio3';
+  testRadio = new FormControl(this.radio2);
+}

--- a/angular-ids-wc/src/app/components/ids-reactive-forms/ids-reactive-forms-routing.module.ts
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/ids-reactive-forms-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { IdsReactiveFormsComponent } from './ids-reactive-forms.component';
 import { ExampleComponent } from './demos/example/example.component';
+import { FormControlComponent } from './demos/form-control/form-control.component';
 
 export const routes: Routes = [
   {
@@ -14,7 +15,15 @@ export const routes: Routes = [
     component: ExampleComponent,
     data: {
       type: 'Example',
-      description: 'All fields in a reactive form'
+      description: 'All fields in a reactive form '
+    }
+  },
+  {
+    path: 'form-control',
+    component: FormControlComponent,
+    data: {
+      type: 'Example',
+      description: 'FormControl and value binding'
     }
   }
 ];

--- a/angular-ids-wc/src/app/components/ids-reactive-forms/ids-reactive-forms.module.ts
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/ids-reactive-forms.module.ts
@@ -6,12 +6,14 @@ import { IdsReactiveFormsRoutingModule } from './ids-reactive-forms-routing.modu
 import { IdsReactiveFormsComponent } from './ids-reactive-forms.component';
 import { ExampleComponent } from './demos/example/example.component';
 import { DemoListingModule } from '../demo-listing/demo-listing.module';
+import { FormControlComponent } from './demos/form-control/form-control.component';
 
 
 @NgModule({
   declarations: [
     IdsReactiveFormsComponent,
-    ExampleComponent
+    ExampleComponent,
+    FormControlComponent
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Added radio group with form control and value binding to Angular reactive form examples to showcase https://github.com/infor-design/enterprise-wc/issues/2700 issue fix

**Related github/jira issue(s) (required)**:
Related https://github.com/infor-design/enterprise-wc/issues/2700

**Steps necessary to review your pull request (required)**:
- pull and run Angular examples
- go to http://localhost:4200/ids-reactive-forms/form-control
- radio two should be checked
