### PR TITLE
2602 - ids-dropdown add value-accessor to fix ngValue

### DIFF
--- a/angular-ids-wc/src/app/components/ids-dropdown/demos/sandbox/sandbox.component.html
+++ b/angular-ids-wc/src/app/components/ids-dropdown/demos/sandbox/sandbox.component.html
@@ -19,32 +19,48 @@
         Change sourceKey to 'idx'
       </ids-button>
 
-      <select
-        name="cars value"
-        id="cars-value"
-        [ngModel]="selectedOption().idx"
-        (ngModelChange)="onSelectionChange($event)"
-      >
-        @for (car of carOptions; track car.id) {
-          <option [value]="car.idx">{{ car[sourceKey()] }}</option>
-        }
-      </select>
-
-      <ids-dropdown
-        #dropdownCar
-        id="dropdown-car"
-        label="Car Dropdown"
-        [ngModel]="selectedOption().idx"
-        (ngModelChange)="onSelectionChange($event)"
-      >
+      <ids-dropdown #dropdownCar id="dropdown-car" label="Car Dropdown" [ngModel]="selectedOption().idx"
+        (ngModelChange)="onSelectionChange($event)">
         <ids-list-box>
           @for (car of carOptions; track car.id) {
-            <ids-list-box-option [value]="car.idx">
-              {{ car[sourceKey()] }}
-            </ids-list-box-option>
+          <ids-list-box-option [value]="car.idx">
+            {{ car[sourceKey()] }}
+          </ids-list-box-option>
           }
         </ids-list-box>
       </ids-dropdown>
+
+      <label for="cars-value">Car Select: </label>
+      <select name="cars value" id="cars-value" [ngModel]="selectedOption().idx"
+        (ngModelChange)="onSelectionChange($event)">
+        @for (car of carOptions; track car.id) {
+        <option [value]="car.idx">{{ car[sourceKey()] }}</option>
+        }
+      </select>
+
+    </ids-layout-grid-cell>
+  </ids-layout-grid>
+  <ids-layout-grid auto-fit="true" padding="md">
+
+    <ids-layout-grid-cell>
+
+      <ids-dropdown name="dropdown-ngval" #dropdownCarNgValue id="dropdown-car-ngValue" label="Car Dropdown (ngValue)" [ngModel]="selectedOption()"
+        (ngModelChange)="onSelectionChange2($event)">
+        <ids-list-box>
+          @for (car of carOptions; track car.id) {
+          <ids-list-box-option [ngValue]="car">
+            {{ car.name }}
+          </ids-list-box-option>
+          }
+        </ids-list-box>
+      </ids-dropdown>
+
+      <label for="cars-ngValue">Car Select (ngValue): </label>
+      <select name="cars-ngval" id="cars-ngValue" [ngModel]="selectedOption()" (ngModelChange)="onSelectionChange2($event)">
+        @for (car of carOptions; track car.id) {
+        <option [ngValue]="car">{{ car.name }}</option>
+        }
+      </select>
     </ids-layout-grid-cell>
   </ids-layout-grid>
 </ids-container>

--- a/angular-ids-wc/src/app/components/ids-dropdown/demos/sandbox/sandbox.component.ts
+++ b/angular-ids-wc/src/app/components/ids-dropdown/demos/sandbox/sandbox.component.ts
@@ -7,8 +7,11 @@ import { Component, AfterViewInit, ViewChild, ElementRef, Input, signal } from '
 })
 export class SandBoxComponent implements AfterViewInit {
   @ViewChild('dropdownCar', { read: ElementRef }) dropdownCar;
+  @ViewChild('dropdownCarNgValue', { read: ElementRef }) dropdownCarNgValue;
 
-  constructor() { }
+  constructor() {
+    console.log('carOptions', this.carOptions);
+   }
 
   carOptions = [
     { name: "volvo", id: 1, idx: "1718693262079751588" },
@@ -24,6 +27,7 @@ export class SandBoxComponent implements AfterViewInit {
   sourceKey = signal("name");
 
   onSelectionChange($event: string): void {
+    console.log('onSelectionChange', $event);
     const newSelectedOption = this.carOptions.find((car) => car.idx === $event);
     this.selectedOption.set(newSelectedOption);
   }
@@ -35,5 +39,11 @@ export class SandBoxComponent implements AfterViewInit {
 
   changeSourceKey(sourceKey: string): void {
     this.sourceKey.set(sourceKey);
+  }
+
+  onSelectionChange2($event: { name: string; id: number, idx: string }): void {
+    console.log('onSelectionChange2', $event);
+    const newSelectedOption = this.carOptions.find((car) => car === $event);
+    this.selectedOption.set(newSelectedOption);
   }
 }

--- a/angular-ids-wc/src/directives/ids-form-accessors.module.ts
+++ b/angular-ids-wc/src/directives/ids-form-accessors.module.ts
@@ -1,17 +1,27 @@
-import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { IdsDefaultValueAccessor, IdsCheckboxValueAccessor, IdsRadioValueAccessor } from './ids-form-accessors';
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import {
+  IdsDefaultValueAccessor,
+  IdsCheckboxValueAccessor,
+  IdsRadioValueAccessor,
+  IdsSelectControlValueAccessor,
+  IdsNgSelectOption,
+} from "./ids-form-accessors";
 
 @NgModule({
   imports: [
     IdsDefaultValueAccessor,
     IdsCheckboxValueAccessor,
     IdsRadioValueAccessor,
+    IdsSelectControlValueAccessor,
+    IdsNgSelectOption,
   ],
   exports: [
     IdsDefaultValueAccessor,
     IdsCheckboxValueAccessor,
     IdsRadioValueAccessor,
+    IdsSelectControlValueAccessor,
+    IdsNgSelectOption,
   ],
-  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
-export class IdsFormAccessorsModule { }
+export class IdsFormAccessorsModule {}

--- a/angular-ids-wc/src/directives/ids-form-accessors.ts
+++ b/angular-ids-wc/src/directives/ids-form-accessors.ts
@@ -88,8 +88,6 @@ export class IdsCheckboxValueAccessor extends CheckboxControlValueAccessor {
 })
 export class IdsRadioValueAccessor extends RadioControlValueAccessor {}
 
-
-
 @Directive({
   selector: `
     ids-dropdown[formControlName],ids-dropdown[formControl],ids-dropdown[ngModel],
@@ -122,6 +120,10 @@ export class IdsSelectControlValueAccessor extends SelectControlValueAccessor {}
 })
 export class IdsNgSelectOption extends NgSelectOption {
   constructor() {
-    super(inject(ElementRef), inject(Renderer2), inject(IdsSelectControlValueAccessor));
+    super(
+      inject(ElementRef),
+      inject(Renderer2),
+      inject(IdsSelectControlValueAccessor)
+    );
   }
 }

--- a/angular-ids-wc/src/directives/ids-form-accessors.ts
+++ b/angular-ids-wc/src/directives/ids-form-accessors.ts
@@ -1,13 +1,26 @@
 /* eslint-disable @angular-eslint/directive-class-suffix */
 /* eslint-disable @angular-eslint/directive-selector */
-import { Directive, ElementRef, Renderer2, forwardRef, inject } from "@angular/core";
-import { DefaultValueAccessor, CheckboxControlValueAccessor, NG_VALUE_ACCESSOR, RadioControlValueAccessor, COMPOSITION_BUFFER_MODE } from "@angular/forms";
+import {
+  Directive,
+  ElementRef,
+  Renderer2,
+  forwardRef,
+  inject,
+} from "@angular/core";
+import {
+  DefaultValueAccessor,
+  CheckboxControlValueAccessor,
+  NG_VALUE_ACCESSOR,
+  RadioControlValueAccessor,
+  COMPOSITION_BUFFER_MODE,
+  NgSelectOption,
+  SelectControlValueAccessor,
+} from "@angular/forms";
 
 @Directive({
   selector: `
     ids-input[formControlName],ids-input[formControl],ids-input[ngModel],
     ids-textarea[formControlName],ids-textarea[formControl],ids-textarea[ngModel],
-    ids-dropdown[formControlName],ids-dropdown[formControl],ids-dropdown[ngModel],
     ids-multiselect[formControlName],ids-multiselect[formControl],ids-multiselect[ngModel],
     ids-radio-group[formControlName],ids-radio-group[formControl],ids-radio-group[ngModel],
     ids-lookup[formControlName],ids-lookup[formControl],ids-lookup[ngModel],
@@ -31,7 +44,11 @@ import { DefaultValueAccessor, CheckboxControlValueAccessor, NG_VALUE_ACCESSOR, 
 })
 export class IdsDefaultValueAccessor extends DefaultValueAccessor {
   constructor() {
-    super(inject(Renderer2), inject(ElementRef), inject(COMPOSITION_BUFFER_MODE, { optional: true }));
+    super(
+      inject(Renderer2),
+      inject(ElementRef),
+      inject(COMPOSITION_BUFFER_MODE, { optional: true })
+    );
   }
 }
 
@@ -69,4 +86,42 @@ export class IdsCheckboxValueAccessor extends CheckboxControlValueAccessor {
     },
   ],
 })
-export class IdsRadioValueAccessor extends RadioControlValueAccessor { }
+export class IdsRadioValueAccessor extends RadioControlValueAccessor {}
+
+
+
+@Directive({
+  selector: `
+    ids-dropdown[formControlName],ids-dropdown[formControl],ids-dropdown[ngModel],
+  `,
+  standalone: true,
+  providers: [
+    {
+      // @see https://angular.io/errors/NG01203#ng01203-you-must-register-an-ngvalueaccessor-with-a-custom-form-control
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => IdsSelectControlValueAccessor),
+      multi: true,
+    },
+  ],
+})
+export class IdsSelectControlValueAccessor extends SelectControlValueAccessor {}
+
+@Directive({
+  selector: `
+    ids-list-box-option,
+  `,
+  standalone: true,
+  providers: [
+    {
+      // @see https://angular.io/errors/NG01203#ng01203-you-must-register-an-ngvalueaccessor-with-a-custom-form-control
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => IdsNgSelectOption),
+      multi: true,
+    },
+  ],
+})
+export class IdsNgSelectOption extends NgSelectOption {
+  constructor() {
+    super(inject(ElementRef), inject(Renderer2), inject(IdsSelectControlValueAccessor));
+  }
+}


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added `IdsSelectControlValueAccessor` and `IdsNgSelectOption` to fix bug where `ngValue` was not working on `ids-list-box-option`.

**Related github/jira issue(s) (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Closes https://github.com/infor-design/enterprise-wc/issues/2602

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
1. Check out this [branch](https://github.com/infor-design/enterprise-wc/pull/2815) and run: `nvm i && nvm use && npm i && npm run start`
2. Ensure no regressions here: http://localhost:4300/ids-dropdown/dynamic-presentation.html
3. In another terminal window, and run `npm run publish:link`
4. Then check out `2602-ids-dropdown-add-accessor-to-fix-ngValue` branch on `enterprise-wc-examples` repository.
5. Then run: `npm i && npm link ids-enterprise-wc`
6. Then run: `rm -fr .angular/cache && nvm i && nvm use && npm run build && npm run start`
7. Then confirm dropdowns change properly here: http://localhost:4200/ids-dropdown/sandbox

**Included in this Pull Request**:
- [x] Added `IdsSelectControlValueAccessor` to control `ids-dropdown`
- [x] Added `IdsNgSelectOption` to support `ngValue` on `ids-list-box-option`
- [x] Added example to demonstrate that `ngValue` now works with `ids-list-box-option`
