### PR TITLE
2686 - ids-dropdown listbox fix display of 0-value

### DIFF
--- a/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.html
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.html
@@ -46,6 +46,15 @@
           </ids-list-box>
         </ids-dropdown>
 
+        <ids-dropdown label="IDS Dropdown 0-indexed" validate="required" formControlName="testDropdown0Index" ngDefaultControl [attr.value]=0>
+          <ids-list-box>
+            <ids-list-box-option group-label>Destinations</ids-list-box-option>
+            <ids-list-box-option *ngFor="let field of testDropdown0IndexValues; let i = index" [attr.id]="i" [attr.value]="i"
+                >{{ field.address.line1 }} ({{ field.address.city }}, {{ field.address.state }})
+            </ids-list-box-option>
+          </ids-list-box>
+        </ids-dropdown>
+
         <ids-multiselect label="IDS Multiselect" formControlName="testMultiselect" ngDefaultControl>
           <ids-list-box>
             <ids-list-box-option value="blank" id="opt0-ms" aria-label="Blank"><ids-checkbox

--- a/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
+++ b/angular-ids-wc/src/app/components/ids-reactive-forms/demos/example/example.component.ts
@@ -10,6 +10,16 @@ export class ExampleComponent implements OnInit {
 
   public testForm: FormGroup;
 
+  testDropdown0IndexValues = [
+    { address: { line1: '012 Hollywood Blvd', line2: 'Suite 210', city: 'Los Angeles', state: 'CA' } },
+    { address: { line1: '123 South Beach Ave', line2: 'Suite 321', city: 'Miami', state: 'FL' } },
+    { address: { line1: '234 Main St', line2: 'Suite 432', city: 'Atlanta', state: 'GA' } },
+    { address: { line1: '345 Wall St', line2: 'Suite 543', city: 'New York City', state: 'NY' } },
+    { address: { line1: '456 State St', line2: 'Suite 654', city: 'Philadelphia', state: 'PA' } },
+    { address: { line1: '567 Rodeo Dr', line2: 'Suite 765', city: 'Dallas', state: 'TX' } },
+    { address: { line1: '678 Broad St', line2: 'Suite 876', city: 'Seattle', state: 'WA' } },
+  ];
+
   constructor() { }
 
   ngOnInit(): void {
@@ -20,7 +30,8 @@ export class ExampleComponent implements OnInit {
       testDateObject: new FormControl(new Date()),
       testDateString: new FormControl('12/31/2020'),
       testDropdown: new FormControl('opt5'),
-      testMultiselect: new FormControl(['opt1', 'opt1']),
+      testDropdown0Index: new FormControl(null),
+      testMultiselect: new FormControl(['opt1', 'opt3']),
       testInput: new FormControl('Original value', Validators.minLength(2)),
       testLookup: new FormControl(),
       testTextarea: new FormControl(),
@@ -41,6 +52,7 @@ export class ExampleComponent implements OnInit {
     console.log(`FormControl(testDateObject) value is: ${this.testForm.controls['testDateObject'].value}`);
     console.log(`FormControl(testDateString) value is: ${this.testForm.controls['testDateString'].value}`);
     console.log(`FormControl(testDropdown) value is: ${this.testForm.controls['testDropdown'].value}`);
+    console.log(`FormControl(testDropdown0Index) value is: ${this.testForm.controls['testDropdown0Index'].value}`);
     console.log(`FormControl(testMultiselect) value is: ${this.testForm.controls['testMultiselect'].value}`);
     console.log(`FormControl(testInput) value is: ${this.testForm.controls['testInput'].value}`);
     console.log(`FormControl(testLookup) value is: ${this.testForm.controls['testLookup'].value}`);
@@ -73,6 +85,16 @@ export class ExampleComponent implements OnInit {
       opt6: 'blank',
     }[this.testForm.controls['testDropdown'].value] ?? 'opt1';
 
+    const nextDropdown0IndexValue = {
+      0: 1,
+      1: 2,
+      2: 3,
+      3: 4,
+      4: 5,
+      5: 6,
+      6: 0,
+    }[this.testForm.controls['testDropdown0Index'].value] ?? 1;
+
     const nextMultiselectValue = {
       blank: 'opt1',
       opt1: 'opt2',
@@ -102,8 +124,9 @@ export class ExampleComponent implements OnInit {
     this.testForm.controls['testSearchField'].setValue(randomText(3));
 
     this.testForm.controls['testDropdown'].setValue(nextDropdownValue);
+    this.testForm.controls['testDropdown0Index'].setValue(nextDropdown0IndexValue);
     this.testForm.controls['testMultiselect'].setValue(nextMultiselectValue);
-    
+
     this.testForm.controls['testRadio'].setValue(nextRadioValue);
 
     this.testForm.controls['testSpinbox'].setValue(Math.floor(Math.random() * 100));


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Add example to test this [ticket](https://github.com/infor-design/enterprise-wc/issues/2686) which points out a bug where 0-indexed values are not being properly displayed in `ids-dropdown`.  

**Related github/jira issue(s) (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100" or "Fixes #1230")
-->
Related: https://github.com/infor-design/enterprise-wc/issues/2686
Main PR: https://github.com/infor-design/enterprise-wc/pull/2821

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
1. Check out branch `2686-dropdown-listbox-display-0-value` from this repository: https://github.com/infor-design/enterprise-wc-examples
2. Then run: `npm install`
3. Then run: `rm -fr .angular/cache && nvm i && nvm use && npm run build && npm run start`
4. Then see `IDS Dropdown 0-indexed` examples here: http://localhost:4200/ids-reactive-forms/example
5. Keep clicking the `Update Values` button and ensure new dropdown cycles through each option without ever skipping the first 0-indexed value.

**Included in this Pull Request**:
- [x] Added `IDS Dropdown 0-indexed` example to http://localhost:4200/ids-reactive-forms/example
